### PR TITLE
Fix Core `liveData` version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -44,7 +44,7 @@ dependencies {
     api 'androidx.constraintlayout:constraintlayout:2.1.4'
     api 'androidx.coordinatorlayout:coordinatorlayout:1.2.0'
     api 'androidx.core:core-ktx:1.9.0'
-    api 'androidx.lifecycle:lifecycle-livedata-ktx:2.6.0'
+    api "androidx.lifecycle:lifecycle-livedata-ktx:$livedata_version"
     api 'androidx.recyclerview:recyclerview:1.3.0'
     api 'androidx.swiperefreshlayout:swiperefreshlayout:1.1.0'
 


### PR DESCRIPTION
LiveData 2.6.0 cause compilation error on kDrive, so we dissociate the version for kMail and kDrive