### PR TITLE
fix: Update bearer token from TokenAuthenticator

### DIFF
--- a/src/main/java/com/infomaniak/lib/core/auth/CredentialManager.kt
+++ b/src/main/java/com/infomaniak/lib/core/auth/CredentialManager.kt
@@ -50,6 +50,7 @@ abstract class CredentialManager {
         user?.let {
             it.apiToken = apiToken
             userDatabase.userDao().update(it)
+            if (currentUserId == it.id) currentUser = it
         }
     }
 
@@ -88,9 +89,6 @@ abstract class CredentialManager {
             val tokenInterceptorListener = object : TokenInterceptorListener {
                 override suspend fun onRefreshTokenSuccess(apiToken: ApiToken) {
                     setUserToken(user, apiToken)
-                    if (currentUserId == userId) {
-                        currentUser = user
-                    }
                 }
 
                 override suspend fun onRefreshTokenError() {

--- a/src/main/java/com/infomaniak/lib/core/auth/TokenAuthenticator.kt
+++ b/src/main/java/com/infomaniak/lib/core/auth/TokenAuthenticator.kt
@@ -17,7 +17,6 @@
  */
 package com.infomaniak.lib.core.auth
 
-import com.infomaniak.lib.core.InfomaniakCore
 import com.infomaniak.lib.core.api.ApiController
 import com.infomaniak.lib.login.ApiToken
 import kotlinx.coroutines.Dispatchers
@@ -44,7 +43,6 @@ class TokenAuthenticator(
                     return@runBlocking changeAccessToken(request, apiToken)
                 } else {
                     apiToken = ApiController.refreshToken(apiToken.refreshToken, tokenInterceptorListener)
-                    InfomaniakCore.bearerToken = apiToken.accessToken
                     return@runBlocking changeAccessToken(request, apiToken)
                 }
             }

--- a/src/main/java/com/infomaniak/lib/core/auth/TokenAuthenticator.kt
+++ b/src/main/java/com/infomaniak/lib/core/auth/TokenAuthenticator.kt
@@ -17,6 +17,7 @@
  */
 package com.infomaniak.lib.core.auth
 
+import com.infomaniak.lib.core.InfomaniakCore
 import com.infomaniak.lib.core.api.ApiController
 import com.infomaniak.lib.login.ApiToken
 import kotlinx.coroutines.Dispatchers
@@ -43,6 +44,7 @@ class TokenAuthenticator(
                     return@runBlocking changeAccessToken(request, apiToken)
                 } else {
                     apiToken = ApiController.refreshToken(apiToken.refreshToken, tokenInterceptorListener)
+                    InfomaniakCore.bearerToken = apiToken.accessToken
                     return@runBlocking changeAccessToken(request, apiToken)
                 }
             }


### PR DESCRIPTION
The bearerToken was not updated when the token was refreshed, so requests using it won't be updated either.