### PR TITLE
Make default Avatars always null by removing the choice

### DIFF
--- a/src/main/java/com/infomaniak/lib/core/api/ApiRepositoryCore.kt
+++ b/src/main/java/com/infomaniak/lib/core/api/ApiRepositoryCore.kt
@@ -28,7 +28,6 @@ abstract class ApiRepositoryCore {
         withEmails: Boolean = false,
         withPhones: Boolean = false,
         withSecurity: Boolean = false,
-        ignoreDefaultAvatar: Boolean = false,
     ): ApiResponse<User> {
         var with = ""
         if (withEmails) with += "emails"
@@ -36,7 +35,7 @@ abstract class ApiRepositoryCore {
         if (withSecurity) with += "security"
         if (with.isNotEmpty()) with = "?with=$with"
 
-        val url = "${ApiRoutesCore.getUserProfile(ignoreDefaultAvatar)}$with"
+        val url = "${ApiRoutesCore.getUserProfile()}$with"
         return ApiController.callApi(url, ApiController.ApiMethod.GET, okHttpClient = okHttpClient)
     }
 }

--- a/src/main/java/com/infomaniak/lib/core/api/ApiRoutesCore.kt
+++ b/src/main/java/com/infomaniak/lib/core/api/ApiRoutesCore.kt
@@ -21,9 +21,8 @@ import com.infomaniak.lib.core.BuildConfig.INFOMANIAK_API
 
 object ApiRoutesCore {
 
-    fun getUserProfile(ignoreDefaultAvatar: Boolean): String {
-        val args = if (ignoreDefaultAvatar) "?no_avatar_default=1" else ""
-        return "${INFOMANIAK_API}profile$args"
+    fun getUserProfile(): String {
+        return "${INFOMANIAK_API}profile?no_avatar_default=1"
     }
 
 }


### PR DESCRIPTION
The API used to work like this, the default avatars that actually point to somewhere was changed without our consent, so this only brings back the logic avatars were built with.