### PR TITLE
Fix missing custom interceptors and sentry interceptor in some http clients

### DIFF
--- a/src/main/java/com/infomaniak/lib/core/auth/CredentialManager.kt
+++ b/src/main/java/com/infomaniak/lib/core/auth/CredentialManager.kt
@@ -19,10 +19,7 @@ package com.infomaniak.lib.core.auth
 
 import androidx.collection.ArrayMap
 import androidx.lifecycle.LiveData
-import com.facebook.stetho.okhttp3.StethoInterceptor
-import com.infomaniak.lib.core.BuildConfig
 import com.infomaniak.lib.core.models.user.User
-import com.infomaniak.lib.core.networking.GZipInterceptor
 import com.infomaniak.lib.core.networking.HttpClientConfig
 import com.infomaniak.lib.core.room.UserDatabase
 import com.infomaniak.lib.login.ApiToken
@@ -79,9 +76,6 @@ abstract class CredentialManager {
 
     private suspend fun getHttpClientUser(userId: Int, timeout: Long?): OkHttpClient {
         return OkHttpClient.Builder().apply {
-            if (BuildConfig.DEBUG) {
-                addNetworkInterceptor(StethoInterceptor())
-            }
             timeout?.let {
                 callTimeout(timeout, TimeUnit.SECONDS)
                 readTimeout(timeout, TimeUnit.SECONDS)
@@ -106,8 +100,8 @@ abstract class CredentialManager {
             }
 
             HttpClientConfig.apply { cacheDir?.let { cache(Cache(it, CACHE_SIZE_BYTES)) } }
+            HttpClientConfig.addCommonInterceptors(this)
 
-            addInterceptor(GZipInterceptor())
             addInterceptor(TokenInterceptor(tokenInterceptorListener))
             authenticator(TokenAuthenticator(tokenInterceptorListener))
         }.run {

--- a/src/main/java/com/infomaniak/lib/core/networking/HttpClient.kt
+++ b/src/main/java/com/infomaniak/lib/core/networking/HttpClient.kt
@@ -17,12 +17,9 @@
  */
 package com.infomaniak.lib.core.networking
 
-import com.facebook.stetho.okhttp3.StethoInterceptor
-import com.infomaniak.lib.core.BuildConfig
 import com.infomaniak.lib.core.auth.TokenAuthenticator
 import com.infomaniak.lib.core.auth.TokenInterceptor
 import com.infomaniak.lib.core.auth.TokenInterceptorListener
-import io.sentry.okhttp.SentryOkHttpInterceptor
 import okhttp3.Cache
 import okhttp3.OkHttpClient
 import java.util.concurrent.TimeUnit
@@ -72,10 +69,7 @@ object HttpClient {
     }
 
     private fun OkHttpClient.Builder.addInterceptors() {
-        if (BuildConfig.DEBUG) addNetworkInterceptor(StethoInterceptor())
-        addInterceptor(GZipInterceptor())
-        addInterceptor(SentryOkHttpInterceptor(captureFailedRequests = true))
-        HttpClientConfig.customInterceptors?.forEach(::addInterceptor)
+        HttpClientConfig.addCommonInterceptors(this)
     }
 
     private fun OkHttpClient.Builder.addTokenInterceptor() {

--- a/src/main/java/com/infomaniak/lib/core/networking/HttpClientConfig.kt
+++ b/src/main/java/com/infomaniak/lib/core/networking/HttpClientConfig.kt
@@ -17,7 +17,11 @@
  */
 package com.infomaniak.lib.core.networking
 
+import com.facebook.stetho.okhttp3.StethoInterceptor
+import com.infomaniak.lib.core.BuildConfig
+import io.sentry.okhttp.SentryOkHttpInterceptor
 import okhttp3.Interceptor
+import okhttp3.OkHttpClient
 import java.io.File
 
 object HttpClientConfig {
@@ -27,4 +31,12 @@ object HttpClientConfig {
     var cacheDir: File? = null
     var customInterceptors: List<Interceptor>? = null
     var customTimeoutMinutes = 2L
+
+    fun addCommonInterceptors(builder: OkHttpClient.Builder) = with(builder) {
+        if (BuildConfig.DEBUG) addNetworkInterceptor(StethoInterceptor())
+        addInterceptor(GZipInterceptor())
+        addInterceptor(SentryOkHttpInterceptor(captureFailedRequests = true))
+        customInterceptors?.forEach(::addInterceptor)
+
+    }
 }

--- a/src/main/java/com/infomaniak/lib/core/networking/HttpClientConfig.kt
+++ b/src/main/java/com/infomaniak/lib/core/networking/HttpClientConfig.kt
@@ -37,6 +37,5 @@ object HttpClientConfig {
         addInterceptor(GZipInterceptor())
         addInterceptor(SentryOkHttpInterceptor(captureFailedRequests = true))
         customInterceptors?.forEach(::addInterceptor)
-
     }
 }

--- a/src/main/java/com/infomaniak/lib/core/utils/CoilUtils.kt
+++ b/src/main/java/com/infomaniak/lib/core/utils/CoilUtils.kt
@@ -24,12 +24,9 @@ import coil.decode.GifDecoder
 import coil.decode.ImageDecoderDecoder
 import coil.disk.DiskCache
 import coil.memory.MemoryCache
-import com.facebook.stetho.okhttp3.StethoInterceptor
-import com.infomaniak.lib.core.BuildConfig
 import com.infomaniak.lib.core.auth.TokenAuthenticator
 import com.infomaniak.lib.core.auth.TokenInterceptor
 import com.infomaniak.lib.core.auth.TokenInterceptorListener
-import com.infomaniak.lib.core.networking.GZipInterceptor
 import com.infomaniak.lib.core.networking.HttpClientConfig
 import com.infomaniak.lib.core.networking.HttpUtils
 import okhttp3.Cache
@@ -74,6 +71,7 @@ object CoilUtils {
                 OkHttpClient.Builder().apply {
 
                     HttpClientConfig.apply { cacheDir?.let { cache(Cache(it, CACHE_SIZE_BYTES)) } }
+                    HttpClientConfig.addCommonInterceptors(this)
 
                     tokenInterceptorListener?.let {
                         addInterceptor(Interceptor { chain ->
@@ -82,12 +80,9 @@ object CoilUtils {
                                 .build()
                                 .let(chain::proceed)
                         })
-                        addInterceptor(GZipInterceptor())
+
                         addInterceptor(TokenInterceptor(it))
                         authenticator(TokenAuthenticator(it))
-                    }
-                    if (BuildConfig.DEBUG) {
-                        addNetworkInterceptor(StethoInterceptor())
                     }
                 }.build()
             }


### PR DESCRIPTION
Up till now Stetho, Sentry and custom interceptors were not added in all our http clients. I factorized their addition so they are added everywhere and so we will be less likely to forget to add them if we ever create a new http client elsewhere