### PR TITLE
Fix: When ApiError the context field throws an exception

### DIFF
--- a/src/main/java/com/infomaniak/lib/core/api/ApiController.kt
+++ b/src/main/java/com/infomaniak/lib/core/api/ApiController.kt
@@ -34,8 +34,6 @@ import com.infomaniak.lib.core.networking.HttpUtils
 import com.infomaniak.lib.core.utils.CustomDateTypeAdapter
 import com.infomaniak.lib.core.utils.isNetworkException
 import com.infomaniak.lib.login.ApiToken
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.withContext
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonObject
@@ -110,41 +108,50 @@ object ApiController {
 
         if (InfomaniakCore.accessType == null) formBuilder.addFormDataPart("duration", "infinite")
 
-        return withContext(Dispatchers.IO) {
-            val request = Request.Builder()
-                .url("${LOGIN_ENDPOINT_URL}token")
-                .post(formBuilder.build())
-                .build()
+        val request = Request.Builder()
+            .url("${LOGIN_ENDPOINT_URL}token")
+            .post(formBuilder.build())
+            .build()
 
-            val response = HttpClient.okHttpClientNoTokenInterceptor.newCall(request).execute()
-            response.use {
-                val bodyResponse = it.body?.string()
+        val apiToken = HttpClient.okHttpClientNoTokenInterceptor.newCall(request).execute().use {
+            val bodyResponse = it.body?.string()
 
-                when {
-                    it.isSuccessful -> {
-                        val apiToken = gson.fromJson(bodyResponse, ApiToken::class.java)
-                        apiToken.expiresAt = System.currentTimeMillis() + (apiToken.expiresIn * 1_000)
-                        tokenInterceptorListener.onRefreshTokenSuccess(apiToken)
-                        return@withContext apiToken
-                    }
-                    else -> {
-                        var invalidGrant = false
-                        runCatching {
-                            invalidGrant = JsonParser.parseString(bodyResponse)
-                                .asJsonObject
-                                .getAsJsonPrimitive("error")
-                                .asString == "invalid_grant"
-                        }
-
-                        if (invalidGrant) {
-                            tokenInterceptorListener.onRefreshTokenError()
-                            throw RefreshTokenException()
-                        }
-                        throw Exception(bodyResponse)
-                    }
+            when {
+                it.isSuccessful -> {
+                    getApiToken(bodyResponse, tokenInterceptorListener)
+                }
+                else -> {
+                    handleInvalidGrant(bodyResponse, tokenInterceptorListener)
+                    throw Exception(bodyResponse)
                 }
             }
         }
+
+        return apiToken
+    }
+
+    private suspend fun handleInvalidGrant(bodyResponse: String?, tokenInterceptorListener: TokenInterceptorListener) {
+        val invalidGrant = runCatching {
+            JsonParser.parseString(bodyResponse)
+                .asJsonObject
+                .getAsJsonPrimitive("error")
+                .asString == "invalid_grant"
+        }.getOrDefault(false)
+
+        if (invalidGrant) {
+            tokenInterceptorListener.onRefreshTokenError()
+            throw RefreshTokenException()
+        }
+    }
+
+    private suspend fun getApiToken(
+        bodyResponse: String?,
+        tokenInterceptorListener: TokenInterceptorListener
+    ): ApiToken {
+        val apiToken = gson.fromJson(bodyResponse, ApiToken::class.java)
+        apiToken.expiresAt = System.currentTimeMillis() + (apiToken.expiresIn * 1_000)
+        tokenInterceptorListener.onRefreshTokenSuccess(apiToken)
+        return apiToken
     }
 
     class RefreshTokenException : Exception()
@@ -184,17 +191,7 @@ object ApiController {
                         )
                     }
                     bodyResponse.isBlank() -> createInternetErrorResponse(buildErrorResult = buildErrorResult)
-                    else -> {
-                        val decodedApiResponse = if (useKotlinxSerialization) {
-                            json.decodeFromString<T>(bodyResponse)
-                        } else {
-                            gson.fromJson(bodyResponse, object : TypeToken<T>() {}.type)
-                        }
-                        decodedApiResponse.apply {
-                            val apiResponse = this as? ApiResponse<*>
-                            if (apiResponse?.result == ERROR) apiResponse.translatedError = R.string.anErrorHasOccurred
-                        }
-                    }
+                    else -> createApiResponse<T>(useKotlinxSerialization, bodyResponse)
                 }
             }
         } catch (refreshTokenException: RefreshTokenException) {
@@ -216,7 +213,20 @@ object ApiController {
         }
     }
 
-    fun String.bodyResponseToJson(): JsonObject {
+    inline fun <reified T> createApiResponse(useKotlinxSerialization: Boolean, bodyResponse: String): T {
+        val apiResponse = when {
+            useKotlinxSerialization -> json.decodeFromString<T>(bodyResponse)
+            else -> gson.fromJson(bodyResponse, object : TypeToken<T>() {}.type)
+        }
+
+        if (apiResponse is ApiResponse<*> && apiResponse.result == ERROR) {
+            apiResponse.translatedError = R.string.anErrorHasOccurred
+        }
+
+        return apiResponse
+    }
+
+    private fun String.bodyResponseToJson(): JsonObject {
         return JsonObject(mapOf("bodyResponse" to JsonPrimitive(this)))
     }
 

--- a/src/main/java/com/infomaniak/lib/core/api/ApiController.kt
+++ b/src/main/java/com/infomaniak/lib/core/api/ApiController.kt
@@ -146,10 +146,10 @@ object ApiController {
 
     private suspend fun getApiToken(
         bodyResponse: String?,
-        tokenInterceptorListener: TokenInterceptorListener
+        tokenInterceptorListener: TokenInterceptorListener,
     ): ApiToken {
         val apiToken = gson.fromJson(bodyResponse, ApiToken::class.java)
-        apiToken.expiresAt = System.currentTimeMillis() + (apiToken.expiresIn * 1_000)
+        apiToken.expiresAt = System.currentTimeMillis() + (apiToken.expiresIn * 1_000L)
         tokenInterceptorListener.onRefreshTokenSuccess(apiToken)
         return apiToken
     }

--- a/src/main/java/com/infomaniak/lib/core/api/ApiController.kt
+++ b/src/main/java/com/infomaniak/lib/core/api/ApiController.kt
@@ -178,7 +178,7 @@ object ApiController {
                 return when {
                     response.code >= 500 -> {
                         createErrorResponse(
-                            apiError = ApiError(context = bodyResponse.bodyResponseToJson(), exception = ServerErrorException()),
+                            apiError = createApiError(useKotlinxSerialization, bodyResponse, ServerErrorException()),
                             translatedError = R.string.serverError,
                             buildErrorResult = buildErrorResult,
                         )
@@ -208,7 +208,7 @@ object ApiController {
             } else {
                 createErrorResponse(
                     translatedError = R.string.anErrorHasOccurred,
-                    apiError = ApiError(context = bodyResponse.bodyResponseToJson(), exception = exception),
+                    apiError = createApiError(useKotlinxSerialization, bodyResponse, exception = exception),
                     buildErrorResult = buildErrorResult,
                 )
             }
@@ -227,6 +227,12 @@ object ApiController {
         translatedError = if (noNetwork) R.string.noConnection else R.string.connectionError,
         apiError = ApiError(exception = NetworkException()),
         buildErrorResult = buildErrorResult,
+    )
+
+    fun createApiError(useKotlinxSerialization: Boolean, bodyResponse: String, exception: Exception) = ApiError(
+        contextJson = if (useKotlinxSerialization) bodyResponse.bodyResponseToJson() else null,
+        contextGson = if (useKotlinxSerialization) JsonParser.parseString(bodyResponse).asJsonObject else null,
+        exception = exception
     )
 
     inline fun <reified T> createErrorResponse(

--- a/src/main/java/com/infomaniak/lib/core/models/ApiError.kt
+++ b/src/main/java/com/infomaniak/lib/core/models/ApiError.kt
@@ -37,6 +37,4 @@ class ApiError(
     val errors: Array<ApiError>? = null,
     @Contextual
     val exception: Exception? = null
-) {
-
-}
+)

--- a/src/main/java/com/infomaniak/lib/core/models/ApiError.kt
+++ b/src/main/java/com/infomaniak/lib/core/models/ApiError.kt
@@ -17,17 +17,26 @@
  */
 package com.infomaniak.lib.core.models
 
+import com.google.gson.annotations.SerializedName
 import kotlinx.serialization.Contextual
+import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.JsonObject
+import com.google.gson.JsonObject as GsonObject
 
 @Serializable
 class ApiError(
     val code: String? = null,
     val description: String? = null,
     @Contextual
-    val context: JsonObject? = null,
+    @SerializedName("context")
+    var contextGson: GsonObject? = null,
+    @Contextual
+    @SerialName("context")
+    var contextJson: JsonObject? = null,
     val errors: Array<ApiError>? = null,
     @Contextual
     val exception: Exception? = null
-)
+) {
+
+}


### PR DESCRIPTION
This is a temporary fix until we switch everything over to `kotlinx.serialization`