### PR TITLE
fix: Sometimes no connection is received when multiple are available

### DIFF
--- a/src/main/java/com/infomaniak/lib/core/networking/LiveDataNetworkStatus.kt
+++ b/src/main/java/com/infomaniak/lib/core/networking/LiveDataNetworkStatus.kt
@@ -27,7 +27,6 @@ import android.os.Build
 import android.util.Log
 import androidx.lifecycle.LiveData
 import io.sentry.Sentry
-import java.net.UnknownHostException
 
 class LiveDataNetworkStatus(context: Context) : LiveData<Boolean>() {
 
@@ -49,15 +48,11 @@ class LiveDataNetworkStatus(context: Context) : LiveData<Boolean>() {
             postValue(hasAvailableNetwork())
         }
 
-        private fun hasAvailableNetwork() = networks.any { checkInternetConnectivity(it) }
+        private fun hasAvailableNetwork() = networks.any(::hasInternetConnectivity)
 
-        fun checkInternetConnectivity(network: Network): Boolean {
-            return try {
-                network.getByName(ROOT_SERVER_CHECK_URL) != null
-            } catch (e: UnknownHostException) {
-                false
-            }
-        }
+        fun hasInternetConnectivity(network: Network): Boolean = runCatching {
+            network.getByName(ROOT_SERVER_CHECK_URL) != null
+        }.getOrDefault(false)
     }
 
     override fun onActive() {

--- a/src/main/java/com/infomaniak/lib/core/networking/LiveDataNetworkStatus.kt
+++ b/src/main/java/com/infomaniak/lib/core/networking/LiveDataNetworkStatus.kt
@@ -46,7 +46,7 @@ class LiveDataNetworkStatus(context: Context) : LiveData<Boolean>() {
 
         override fun onAvailable(network: Network) {
             networks.add(network)
-            postValue(checkInternetConnectivity(network))
+            postValue(networks.any { checkInternetConnectivity(it) })
         }
 
         fun checkInternetConnectivity(network: Network): Boolean {

--- a/src/main/java/com/infomaniak/lib/core/networking/LiveDataNetworkStatus.kt
+++ b/src/main/java/com/infomaniak/lib/core/networking/LiveDataNetworkStatus.kt
@@ -41,13 +41,15 @@ class LiveDataNetworkStatus(context: Context) : LiveData<Boolean>() {
     private val networkStateObject = object : ConnectivityManager.NetworkCallback() {
         override fun onLost(network: Network) {
             networks.remove(network)
-            postValue(!networks.all { !checkInternetConnectivity(it) })
+            postValue(hasAvailableNetwork())
         }
 
         override fun onAvailable(network: Network) {
             networks.add(network)
-            postValue(networks.any { checkInternetConnectivity(it) })
+            postValue(hasAvailableNetwork())
         }
+
+        private fun hasAvailableNetwork() = networks.any { checkInternetConnectivity(it) }
 
         fun checkInternetConnectivity(network: Network): Boolean {
             return try {


### PR DESCRIPTION
When several connections are available and the last has no Internet access, we publish that there is no connection even though the first has Internet access.