### PR TITLE
Prevent showing and hiding progress crashes

### DIFF
--- a/BugTracker/src/main/java/com/infomaniak/lib/bugtracker/BugTrackerActivity.kt
+++ b/BugTracker/src/main/java/com/infomaniak/lib/bugtracker/BugTrackerActivity.kt
@@ -114,7 +114,7 @@ class BugTrackerActivity : AppCompatActivity() {
                 showToast(R.string.bugTrackerFormSubmitSuccess)
                 finish()
             } else {
-                submitButton.hideProgress(R.string.bugTrackerSubmit)
+                submitButton.hideProgressCatching(R.string.bugTrackerSubmit)
                 showSnackbar(R.string.bugTrackerFormSubmitError)
             }
         }

--- a/BugTracker/src/main/java/com/infomaniak/lib/bugtracker/BugTrackerActivity.kt
+++ b/BugTracker/src/main/java/com/infomaniak/lib/bugtracker/BugTrackerActivity.kt
@@ -89,7 +89,7 @@ class BugTrackerActivity : AppCompatActivity() {
                 } else if (descriptionTextInput.text.isNullOrBlank() || subjectTextInput.text.isNullOrBlank()) {
                     missingFieldsError.isVisible = true
                 } else {
-                    showProgress()
+                    showProgressCatching()
                     sendBugReport()
                 }
             }

--- a/src/main/java/com/infomaniak/lib/core/utils/Extensions.kt
+++ b/src/main/java/com/infomaniak/lib/core/utils/Extensions.kt
@@ -76,8 +76,6 @@ import com.infomaniak.lib.core.utils.Utils.CAMEL_CASE_REGEX
 import com.infomaniak.lib.core.utils.Utils.SNAKE_CASE_REGEX
 import com.infomaniak.lib.core.utils.UtilsUi.generateInitialsAvatarDrawable
 import com.infomaniak.lib.core.utils.UtilsUi.getBackgroundColorBasedOnId
-import io.sentry.Sentry
-import io.sentry.SentryLevel
 import org.apache.commons.cli.MissingArgumentException
 import java.io.Serializable
 import kotlin.properties.ReadWriteProperty
@@ -122,34 +120,20 @@ fun MaterialButton.updateTextColor(color: Int?) {
 }
 
 fun MaterialButton.showProgressCatching(color: Int? = null) {
-    class ShowProgressException(cause: Throwable) : Exception("showProgressCatching failed to show progress", cause)
-
     isClickable = false
+    // showProgress stores references to views which crashes when the view is freed
     runCatching {
         showProgress {
             progressColor = color ?: Color.WHITE
             gravity = GRAVITY_CENTER
         }
-    }.onFailure { exception ->
-        Sentry.withScope { scope ->
-            scope.level = SentryLevel.INFO
-            Sentry.captureException(ShowProgressException(exception))
-        }
     }
 }
 
 fun MaterialButton.hideProgressCatching(@StringRes text: Int) {
-    class HideProgressException(cause: Throwable) : Exception("hideProgressCatching failed to hide progress", cause)
-
     isClickable = true
-    runCatching {
-        hideProgress(text)
-    }.onFailure { exception ->
-        Sentry.withScope { scope ->
-            scope.level = SentryLevel.INFO
-            Sentry.captureException(HideProgressException(exception))
-        }
-    }
+    // hideProgress stores references to views which crashes when the view is freed
+    runCatching { hideProgress(text) }
 }
 
 /**

--- a/src/main/java/com/infomaniak/lib/core/utils/Extensions.kt
+++ b/src/main/java/com/infomaniak/lib/core/utils/Extensions.kt
@@ -68,7 +68,6 @@ import coil.ImageLoader
 import coil.load
 import com.github.razir.progressbutton.*
 import com.github.razir.progressbutton.DrawableButton.Companion.GRAVITY_CENTER
-import com.github.razir.progressbutton.hideProgress
 import com.google.android.material.button.MaterialButton
 import com.infomaniak.lib.core.models.user.User
 import com.infomaniak.lib.core.utils.CoilUtils.simpleImageLoader
@@ -139,9 +138,18 @@ fun MaterialButton.showProgressCatching(color: Int? = null) {
     }
 }
 
-fun MaterialButton.hideProgress(@StringRes text: Int) {
+fun MaterialButton.hideProgressCatching(@StringRes text: Int) {
+    class HideProgressException(cause: Throwable) : Exception("hideProgressCatching failed to hide progress", cause)
+
     isClickable = true
-    hideProgress(text)
+    runCatching {
+        hideProgress(text)
+    }.onFailure { exception ->
+        Sentry.withScope { scope ->
+            scope.level = SentryLevel.INFO
+            Sentry.captureException(HideProgressException(exception))
+        }
+    }
 }
 
 /**

--- a/src/main/java/com/infomaniak/lib/core/utils/Extensions.kt
+++ b/src/main/java/com/infomaniak/lib/core/utils/Extensions.kt
@@ -77,6 +77,8 @@ import com.infomaniak.lib.core.utils.Utils.CAMEL_CASE_REGEX
 import com.infomaniak.lib.core.utils.Utils.SNAKE_CASE_REGEX
 import com.infomaniak.lib.core.utils.UtilsUi.generateInitialsAvatarDrawable
 import com.infomaniak.lib.core.utils.UtilsUi.getBackgroundColorBasedOnId
+import io.sentry.Sentry
+import io.sentry.SentryLevel
 import org.apache.commons.cli.MissingArgumentException
 import java.io.Serializable
 import kotlin.properties.ReadWriteProperty
@@ -120,11 +122,20 @@ fun MaterialButton.updateTextColor(color: Int?) {
     initProgress(color = color)
 }
 
-fun MaterialButton.showProgress(color: Int? = null) {
+fun MaterialButton.showProgressCatching(color: Int? = null) {
+    class ShowProgressException(cause: Throwable) : Exception("showProgressCatching failed to show progress", cause)
+
     isClickable = false
-    showProgress {
-        progressColor = color ?: Color.WHITE
-        gravity = GRAVITY_CENTER
+    runCatching {
+        showProgress {
+            progressColor = color ?: Color.WHITE
+            gravity = GRAVITY_CENTER
+        }
+    }.onFailure { exception ->
+        Sentry.withScope { scope ->
+            scope.level = SentryLevel.INFO
+            Sentry.captureException(ShowProgressException(exception))
+        }
     }
 }
 


### PR DESCRIPTION
The methods showProgress() and hideProgress() keep crashing on many occasions despite our best efforts to do things correctly. This PR wraps the methods that throw to avoid crashing