### PR TITLE
Downgrade robolectric

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -93,5 +93,6 @@ dependencies {
     testImplementation 'androidx.test.ext:junit:1.2.1'
     testImplementation 'androidx.test:core-ktx:1.6.1'
     testImplementation 'androidx.test:core:1.6.1'
-    testImplementation 'org.robolectric:robolectric:4.13'
+    //Don't update this because it breaks tests
+    testImplementation 'org.robolectric:robolectric:4.12.2'
 }


### PR DESCRIPTION
Revert rebolectric because it breaks tests in kDrive