### PR TITLE
Also handle error icon's end padding in EndIconTextInputLayout

### DIFF
--- a/src/main/java/com/infomaniak/lib/core/views/EndIconTextInputLayout.kt
+++ b/src/main/java/com/infomaniak/lib/core/views/EndIconTextInputLayout.kt
@@ -40,6 +40,7 @@ class EndIconTextInputLayout @JvmOverloads constructor(
                 resources.getDimensionPixelSize(RCore.dimen.marginStandardMedium),
             )
             findViewById<CheckableImageButton>(R.id.text_input_end_icon)?.setPadding(padding)
+            findViewById<CheckableImageButton>(R.id.text_input_error_icon)?.setPadding(padding)
         }
     }
 }


### PR DESCRIPTION
The same padding bug exists on the error end icon. This PR applies the same fix to this error icon as well