### PR TITLE
Remove sentry only called when receiving 401

### DIFF
--- a/src/main/java/com/infomaniak/lib/core/auth/TokenAuthenticator.kt
+++ b/src/main/java/com/infomaniak/lib/core/auth/TokenAuthenticator.kt
@@ -18,7 +18,6 @@
 package com.infomaniak.lib.core.auth
 
 import com.infomaniak.lib.core.api.ApiController
-import com.infomaniak.lib.core.utils.SentryLog
 import com.infomaniak.lib.login.ApiToken
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.runBlocking
@@ -40,11 +39,7 @@ class TokenAuthenticator(
             mutex.withLock {
                 val request = response.request
                 val authorization = request.header("Authorization")
-                val apiToken = tokenInterceptorListener.getApiToken() ?: run {
-                    // The last user has been disconnected
-                    SentryLog.e("TokenAuthenticator", "Null ApiToken in TokenAuthenticator")
-                    return@runBlocking null
-                }
+                val apiToken = tokenInterceptorListener.getApiToken() ?: return@runBlocking null
                 val isAlreadyRefreshed = apiToken.accessToken != authorization?.replaceFirst("Bearer ", "")
                 val hasUserChanged = userId != tokenInterceptorListener.getCurrentUserId()
 

--- a/src/main/java/com/infomaniak/lib/core/auth/TokenInterceptor.kt
+++ b/src/main/java/com/infomaniak/lib/core/auth/TokenInterceptor.kt
@@ -18,8 +18,6 @@
 package com.infomaniak.lib.core.auth
 
 import com.infomaniak.lib.core.auth.TokenAuthenticator.Companion.changeAccessToken
-import io.sentry.Sentry
-import io.sentry.SentryLevel
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.runBlocking
 import okhttp3.Interceptor
@@ -33,10 +31,7 @@ class TokenInterceptor(
         var request = chain.request()
 
         runBlocking(Dispatchers.IO) {
-            val apiToken = tokenInterceptorListener.getApiToken() ?: run {
-                Sentry.captureMessage("Null ApiToken in TokenInterceptor", SentryLevel.ERROR)
-                return@runBlocking
-            }
+            val apiToken = tokenInterceptorListener.getApiToken() ?: return@runBlocking
             val authorization = request.header("Authorization")
             if (apiToken.accessToken != authorization?.replaceFirst("Bearer ", "")) {
                 request = changeAccessToken(request, apiToken)


### PR DESCRIPTION
Remove because it happens because the user is disconnected due to a 401 error from another call before.