### PR TITLE
Add `Redirect` and `uri` in ApiResponse

### DIFF
--- a/src/main/java/com/infomaniak/lib/core/models/ApiResponse.kt
+++ b/src/main/java/com/infomaniak/lib/core/models/ApiResponse.kt
@@ -26,6 +26,7 @@ import kotlinx.serialization.Serializable
 open class ApiResponse<T>(
     val result: ApiResponseStatus = ApiResponseStatus.UNKNOWN,
     val data: @RawValue T? = null,
+    val uri: String? = null,
     val error: ApiError? = null,
     val page: Int = 0,
     val pages: Int = 0,

--- a/src/main/java/com/infomaniak/lib/core/models/ApiResponseStatus.kt
+++ b/src/main/java/com/infomaniak/lib/core/models/ApiResponseStatus.kt
@@ -36,6 +36,10 @@ enum class ApiResponseStatus {
     @SerializedName("asynchronous")
     ASYNCHRONOUS,
 
+    @SerialName("redirect")
+    @SerializedName("redirect")
+    REDIRECT,
+
     @SerialName("unknown")
     @SerializedName("unknown")
     UNKNOWN;


### PR DESCRIPTION
These fields are needed for the public share link feature