### PR TITLE
Stop throwing RefreshTokenException when the user has an infinite token

### DIFF
--- a/src/main/java/com/infomaniak/lib/core/api/ApiController.kt
+++ b/src/main/java/com/infomaniak/lib/core/api/ApiController.kt
@@ -93,9 +93,9 @@ object ApiController {
         return toJson.toRequestBody(jsonMediaType)
     }
 
-    suspend fun refreshToken(refreshToken: String?, tokenInterceptorListener: TokenInterceptorListener): ApiToken {
+    suspend fun refreshToken(refreshToken: String, tokenInterceptorListener: TokenInterceptorListener): ApiToken {
 
-        if (refreshToken.isNullOrBlank()) {
+        if (refreshToken.isBlank()) {
             tokenInterceptorListener.onRefreshTokenError()
             throw RefreshTokenException()
         }

--- a/src/main/java/com/infomaniak/lib/core/auth/TokenAuthenticator.kt
+++ b/src/main/java/com/infomaniak/lib/core/auth/TokenAuthenticator.kt
@@ -18,6 +18,7 @@
 package com.infomaniak.lib.core.auth
 
 import com.infomaniak.lib.core.api.ApiController
+import com.infomaniak.lib.core.utils.TokenUtils
 import com.infomaniak.lib.login.ApiToken
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.runBlocking
@@ -46,7 +47,7 @@ class TokenAuthenticator(
                 val refreshToken = apiToken.refreshToken
 
                 return@runBlocking when {
-                    hasUserChanged || refreshToken == null -> null
+                    hasUserChanged || TokenUtils.isInfinite(refreshToken) -> null
                     isAlreadyRefreshed -> changeAccessToken(request, apiToken)
                     else -> {
                         val newToken = ApiController.refreshToken(refreshToken, tokenInterceptorListener)

--- a/src/main/java/com/infomaniak/lib/core/auth/TokenAuthenticator.kt
+++ b/src/main/java/com/infomaniak/lib/core/auth/TokenAuthenticator.kt
@@ -18,7 +18,7 @@
 package com.infomaniak.lib.core.auth
 
 import com.infomaniak.lib.core.api.ApiController
-import com.infomaniak.lib.core.utils.TokenUtils
+import com.infomaniak.lib.core.utils.ApiTokenExt.isInfinite
 import com.infomaniak.lib.login.ApiToken
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.runBlocking
@@ -44,13 +44,12 @@ class TokenAuthenticator(
 
                 val isAlreadyRefreshed = apiToken.accessToken != authorization?.replaceFirst("Bearer ", "")
                 val hasUserChanged = userId != tokenInterceptorListener.getCurrentUserId()
-                val refreshToken = apiToken.refreshToken
 
                 return@runBlocking when {
-                    hasUserChanged || TokenUtils.isInfinite(refreshToken) -> null
+                    hasUserChanged || apiToken.isInfinite -> null
                     isAlreadyRefreshed -> changeAccessToken(request, apiToken)
                     else -> {
-                        val newToken = ApiController.refreshToken(refreshToken, tokenInterceptorListener)
+                        val newToken = ApiController.refreshToken(apiToken.refreshToken!!, tokenInterceptorListener)
                         changeAccessToken(request, newToken)
                     }
                 }

--- a/src/main/java/com/infomaniak/lib/core/auth/TokenAuthenticator.kt
+++ b/src/main/java/com/infomaniak/lib/core/auth/TokenAuthenticator.kt
@@ -41,7 +41,6 @@ class TokenAuthenticator(
                 val request = response.request
                 val authorization = request.header("Authorization")
                 val apiToken = tokenInterceptorListener.getApiToken() ?: return@runBlocking null
-
                 val isAlreadyRefreshed = apiToken.accessToken != authorization?.replaceFirst("Bearer ", "")
                 val hasUserChanged = userId != tokenInterceptorListener.getCurrentUserId()
 

--- a/src/main/java/com/infomaniak/lib/core/auth/TokenAuthenticator.kt
+++ b/src/main/java/com/infomaniak/lib/core/auth/TokenAuthenticator.kt
@@ -40,14 +40,16 @@ class TokenAuthenticator(
                 val request = response.request
                 val authorization = request.header("Authorization")
                 val apiToken = tokenInterceptorListener.getApiToken() ?: return@runBlocking null
+
                 val isAlreadyRefreshed = apiToken.accessToken != authorization?.replaceFirst("Bearer ", "")
                 val hasUserChanged = userId != tokenInterceptorListener.getCurrentUserId()
+                val refreshToken = apiToken.refreshToken
 
                 return@runBlocking when {
-                    hasUserChanged -> null
+                    hasUserChanged || refreshToken == null -> null
                     isAlreadyRefreshed -> changeAccessToken(request, apiToken)
                     else -> {
-                        val newToken = ApiController.refreshToken(apiToken.refreshToken, tokenInterceptorListener)
+                        val newToken = ApiController.refreshToken(refreshToken, tokenInterceptorListener)
                         changeAccessToken(request, newToken)
                     }
                 }

--- a/src/main/java/com/infomaniak/lib/core/networking/AccessTokenUsageInterceptor.kt
+++ b/src/main/java/com/infomaniak/lib/core/networking/AccessTokenUsageInterceptor.kt
@@ -18,6 +18,7 @@
 package com.infomaniak.lib.core.networking
 
 import com.infomaniak.lib.core.auth.TokenInterceptorListener
+import com.infomaniak.lib.core.utils.TokenUtils
 import io.sentry.Sentry
 import io.sentry.SentryLevel
 import kotlinx.coroutines.Dispatchers
@@ -42,7 +43,7 @@ class AccessTokenUsageInterceptor(
             val apiToken = tokenInterceptorListener.getApiToken() ?: return@runBlocking
 
             // Only log api calls if we're not using refresh tokens
-            if (apiToken.refreshToken != null) return@runBlocking
+            if (!TokenUtils.isInfinite(apiToken.refreshToken)) return@runBlocking
 
             val currentApiCall = ApiCallRecord(
                 accessToken = request.header("Authorization")?.replaceFirst("Bearer ", "") ?: return@runBlocking,

--- a/src/main/java/com/infomaniak/lib/core/networking/AccessTokenUsageInterceptor.kt
+++ b/src/main/java/com/infomaniak/lib/core/networking/AccessTokenUsageInterceptor.kt
@@ -18,7 +18,7 @@
 package com.infomaniak.lib.core.networking
 
 import com.infomaniak.lib.core.auth.TokenInterceptorListener
-import com.infomaniak.lib.core.utils.TokenUtils
+import com.infomaniak.lib.core.utils.ApiTokenExt.isInfinite
 import io.sentry.Sentry
 import io.sentry.SentryLevel
 import kotlinx.coroutines.Dispatchers
@@ -43,7 +43,7 @@ class AccessTokenUsageInterceptor(
             val apiToken = tokenInterceptorListener.getApiToken() ?: return@runBlocking
 
             // Only log api calls if we're not using refresh tokens
-            if (!TokenUtils.isInfinite(apiToken.refreshToken)) return@runBlocking
+            if (!apiToken.isInfinite) return@runBlocking
 
             val currentApiCall = ApiCallRecord(
                 accessToken = request.header("Authorization")?.replaceFirst("Bearer ", "") ?: return@runBlocking,

--- a/src/main/java/com/infomaniak/lib/core/utils/ApiTokenExt.kt
+++ b/src/main/java/com/infomaniak/lib/core/utils/ApiTokenExt.kt
@@ -17,15 +17,8 @@
  */
 package com.infomaniak.lib.core.utils
 
-import kotlin.contracts.ExperimentalContracts
-import kotlin.contracts.contract
+import com.infomaniak.lib.login.ApiToken
 
-object TokenUtils {
-    @OptIn(ExperimentalContracts::class)
-    fun isInfinite(refreshToken: String?): Boolean {
-        contract {
-            returns(false) implies (refreshToken != null)
-        }
-        return refreshToken == null
-    }
+object ApiTokenExt {
+    val ApiToken.isInfinite get() = refreshToken == null
 }

--- a/src/main/java/com/infomaniak/lib/core/utils/TokenUtils.kt
+++ b/src/main/java/com/infomaniak/lib/core/utils/TokenUtils.kt
@@ -1,0 +1,31 @@
+/*
+ * Infomaniak Core - Android
+ * Copyright (C) 2024 Infomaniak Network SA
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.infomaniak.lib.core.utils
+
+import kotlin.contracts.ExperimentalContracts
+import kotlin.contracts.contract
+
+object TokenUtils {
+    @OptIn(ExperimentalContracts::class)
+    fun isInfinite(refreshToken: String?): Boolean {
+        contract {
+            returns(false) implies (refreshToken != null)
+        }
+        return refreshToken == null
+    }
+}


### PR DESCRIPTION
Having an infinite token means you will never be able to refresh your token, so there should not be an exception while trying to do so. This will remove unimportant RefreshTokenException thrown by infinite tokens in Sentry