### PR TITLE
feat: Introduce LockActivity.scheduleLockIfNeeded with new feature

### DIFF
--- a/AppLock/build.gradle
+++ b/AppLock/build.gradle
@@ -25,4 +25,7 @@ dependencies {
     implementation project(path: ':Core')
 
     implementation 'androidx.biometric:biometric-ktx:1.2.0-alpha05'
+    implementation("com.louiscad.splitties:splitties-appctx:3.0.0")
+    implementation("com.louiscad.splitties:splitties-mainhandler:3.0.0")
+    implementation("com.louiscad.splitties:splitties-systemservices:3.0.0")
 }

--- a/AppLock/build.gradle
+++ b/AppLock/build.gradle
@@ -25,6 +25,7 @@ dependencies {
     implementation project(path: ':Core')
 
     implementation 'androidx.biometric:biometric-ktx:1.2.0-alpha05'
+    implementation("androidx.lifecycle:lifecycle-process:2.8.7")
     implementation("com.louiscad.splitties:splitties-appctx:3.0.0")
     implementation("com.louiscad.splitties:splitties-mainhandler:3.0.0")
     implementation("com.louiscad.splitties:splitties-systemservices:3.0.0")

--- a/AppLock/src/main/java/com/infomaniak/lib/applock/DisplayState.kt
+++ b/AppLock/src/main/java/com/infomaniak/lib/applock/DisplayState.kt
@@ -1,0 +1,76 @@
+/*
+ * Infomaniak Core - Android
+ * Copyright (C) 2024 Infomaniak Network SA
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.infomaniak.lib.applock
+
+import android.hardware.display.DisplayManager
+import android.view.Display
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.channels.awaitClose
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.buffer
+import kotlinx.coroutines.flow.callbackFlow
+import splitties.mainhandler.mainHandler
+import splitties.systemservices.displayManager
+
+sealed interface DisplayState {
+    data object Off : DisplayState
+    data object Vr : DisplayState
+    data object DozeSuspend : DisplayState
+    data object Doze : DisplayState
+    data object OnSuspend : DisplayState
+    data object On : DisplayState
+    data class Unknown(val value: Int) : DisplayState
+
+    companion object {
+
+        fun stateForDisplay(id: Int): Flow<DisplayState?> = callbackFlow {
+            var display: Display? = null
+            val listener = object : DisplayManager.DisplayListener {
+                override fun onDisplayAdded(displayId: Int) {
+                    display = displayManager.getDisplay(id)
+                    trySend(display?.state?.let { from(it) })
+                }
+
+                override fun onDisplayRemoved(displayId: Int) {
+                    display = null
+                    trySend(null)
+                }
+
+                override fun onDisplayChanged(displayId: Int) {
+                    val state = display?.state?.let { from(it) }
+                    trySend(state)
+                }
+            }
+            displayManager.registerDisplayListener(listener, mainHandler)
+            display = displayManager.getDisplay(id)
+            trySend(display?.state?.let { from(it) })
+            awaitClose { displayManager.unregisterDisplayListener(listener) }
+        }.buffer(Channel.UNLIMITED)
+
+        private fun from(state: Int): DisplayState = when (state) {
+            Display.STATE_OFF -> Off
+            Display.STATE_VR -> Vr
+            Display.STATE_DOZE_SUSPEND -> DozeSuspend
+            Display.STATE_DOZE -> Doze
+            Display.STATE_ON_SUSPEND -> OnSuspend
+            Display.STATE_ON -> On
+            Display.STATE_UNKNOWN -> Unknown(state)
+            else -> Unknown(state)
+        }
+    }
+}

--- a/AppLock/src/main/java/com/infomaniak/lib/applock/LockActivity.kt
+++ b/AppLock/src/main/java/com/infomaniak/lib/applock/LockActivity.kt
@@ -132,8 +132,7 @@ class LockActivity : AppCompatActivity() {
         ) {
            targetActivity.lifecycleScope.launch {
                targetActivity.shouldEnableAppLockFlow(isAppLockEnabled).collectLatest { shouldLock ->
-                   if (!shouldLock) return@collectLatest
-                   lockAppWhenNeeded(
+                   if (shouldLock) lockAppWhenNeeded(
                        targetActivity = targetActivity,
                        primaryColor = primaryColor,
                        autoLockTimeout = autoLockTimeout
@@ -142,23 +141,17 @@ class LockActivity : AppCompatActivity() {
            }
         }
 
-        private fun lockAppWhenNeeded(
+        private suspend fun lockAppWhenNeeded(
             targetActivity: ComponentActivity,
             @ColorInt primaryColor: Int,
             autoLockTimeout: Duration
-        ) = targetActivity.lifecycleScope.launch {
-            val lifecycle = targetActivity.lifecycle
-
-            launch {
-                lifecycle.currentStateFlow.collect { state ->
-                    if (state == Lifecycle.State.RESUMED) lockIfNeeded(
-                        targetActivity = targetActivity,
-                        lastAppClosingTime = lastAppClosingTime,
-                        primaryColor = primaryColor,
-                        autoLockTimeout = autoLockTimeout
-                    )
-                }
-            }
+        ): Nothing = targetActivity.lifecycle.currentStateFlow.collect { state ->
+            if (state == Lifecycle.State.RESUMED) lockIfNeeded(
+                targetActivity = targetActivity,
+                lastAppClosingTime = lastAppClosingTime,
+                primaryColor = primaryColor,
+                autoLockTimeout = autoLockTimeout
+            )
         }
 
         private fun ComponentActivity.shouldEnableAppLockFlow(

--- a/AppLock/src/main/java/com/infomaniak/lib/applock/LockActivity.kt
+++ b/AppLock/src/main/java/com/infomaniak/lib/applock/LockActivity.kt
@@ -90,6 +90,7 @@ class LockActivity : AppCompatActivity() {
             }.also(::startActivity)
         }
         lockedByScreenTurnedOff = false
+        lastAppClosingTime = System.currentTimeMillis() // Avoid locking again immediately
         finish()
     }
 

--- a/AppLock/src/main/java/com/infomaniak/lib/applock/LockActivity.kt
+++ b/AppLock/src/main/java/com/infomaniak/lib/applock/LockActivity.kt
@@ -17,20 +17,37 @@
  */
 package com.infomaniak.lib.applock
 
+import android.app.Activity
 import android.content.Context
 import android.content.Intent
 import android.os.Bundle
 import android.util.Log
+import android.view.Display
+import androidx.activity.ComponentActivity
 import androidx.activity.addCallback
 import androidx.activity.viewModels
+import androidx.annotation.ColorInt
 import androidx.appcompat.app.AppCompatActivity
+import androidx.biometric.BiometricManager
+import androidx.biometric.BiometricManager.Authenticators.BIOMETRIC_WEAK
+import androidx.biometric.BiometricManager.Authenticators.DEVICE_CREDENTIAL
+import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.eventFlow
+import androidx.lifecycle.lifecycleScope
 import androidx.navigation.navArgs
 import com.infomaniak.lib.applock.Utils.requestCredentials
 import com.infomaniak.lib.applock.databinding.ActivityLockBinding
 import com.infomaniak.lib.core.utils.getAppName
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.flow.transform
+import kotlinx.coroutines.launch
+import splitties.init.appCtx
 import java.util.Date
 import kotlin.system.exitProcess
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.minutes
 
 class LockActivity : AppCompatActivity() {
     private val binding by lazy { ActivityLockBinding.inflate(layoutInflater) }
@@ -84,7 +101,10 @@ class LockActivity : AppCompatActivity() {
     companion object {
 
         private const val UNDEFINED_PRIMARY_COLOR = 0
-        private const val SECURITY_APP_TOLERANCE = 1 * 60 * 1_000 // 1 min (ms)
+        private val defaultAutoLockTimeout = 1.minutes
+
+        private val biometricsManager = BiometricManager.from(appCtx)
+        private const val authenticators = BIOMETRIC_WEAK or DEVICE_CREDENTIAL
 
         fun startAppLockActivity(
             context: Context,
@@ -99,12 +119,96 @@ class LockActivity : AppCompatActivity() {
             }.also(context::startActivity)
         }
 
+        fun scheduleLockIfNeeded(
+            targetActivity: ComponentActivity,
+            @ColorInt primaryColor: Int = UNDEFINED_PRIMARY_COLOR,
+            autoLockTimeout: Duration = defaultAutoLockTimeout,
+            isAppLockEnabled: () -> Boolean,
+        ) {
+           targetActivity.lifecycleScope.launch {
+               targetActivity.shouldEnableAppLockFlow(isAppLockEnabled).collectLatest { shouldLock ->
+                   if (!shouldLock) return@collectLatest
+                   lockAppWhenNeeded(
+                       targetActivity = targetActivity,
+                       primaryColor = primaryColor,
+                       autoLockTimeout = autoLockTimeout
+                   )
+               }
+           }
+        }
+
+        private fun lockAppWhenNeeded(
+            targetActivity: ComponentActivity,
+            @ColorInt primaryColor: Int,
+            autoLockTimeout: Duration,
+        ) = targetActivity.lifecycleScope.launch {
+            val lifecycle = targetActivity.lifecycle
+
+            var lastAppClosingTime = System.currentTimeMillis()
+            launch {
+                lifecycle.eventFlow.collect { event ->
+                    if (event == Lifecycle.Event.ON_PAUSE) lastAppClosingTime = System.currentTimeMillis()
+                }
+            }
+            launch {
+                lifecycle.currentStateFlow.collect { state ->
+                    if (state == Lifecycle.State.RESUMED) lockIfTimeoutExceeded(
+                        targetActivity = targetActivity,
+                        lastAppClosingTime = lastAppClosingTime,
+                        primaryColor = primaryColor,
+                        autoLockTimeout = autoLockTimeout
+                    )
+                }
+            }
+            launch {
+                DisplayState.stateForDisplay(Display.DEFAULT_DISPLAY).collect { state ->
+                    if (state != DisplayState.On) {
+                        lockNow(targetActivity, primaryColor)
+                    }
+                }
+            }
+        }
+
+        private fun ComponentActivity.shouldEnableAppLockFlow(
+            isAppLockEnabled:() -> Boolean
+        ): Flow<Boolean> = lifecycle.currentStateFlow.transform {
+            if (it == Lifecycle.State.RESUMED) {
+                emit(hasBiometrics() && isAppLockEnabled())
+            }
+        }
+
+        private fun lockIfTimeoutExceeded(
+            targetActivity: Activity,
+            lastAppClosingTime: Long,
+            primaryColor: Int = UNDEFINED_PRIMARY_COLOR,
+            autoLockTimeout: Duration
+        ) {
+            val now = System.currentTimeMillis()
+            if (now > lastAppClosingTime + autoLockTimeout.inWholeMilliseconds) {
+                lockNow(targetActivity, primaryColor)
+            }
+        }
+
+        private fun lockNow(originalActivity: Activity, primaryColor: Int) {
+            startAppLockActivity(
+                originalActivity,
+                originalActivity::class.java,
+                primaryColor = primaryColor,
+                shouldStartActivity = false
+            )
+        }
+
+        private fun hasBiometrics(): Boolean {
+            return biometricsManager.canAuthenticate(authenticators) == BiometricManager.BIOMETRIC_SUCCESS
+        }
+
+        @Deprecated("Use scheduleLockIfNeeded(…) right from onCreate() instead.", level = DeprecationLevel.ERROR)
         fun lockAfterTimeout(
             context: Context,
             destinationClass: Class<*>,
             lastAppClosingTime: Long,
             primaryColor: Int = UNDEFINED_PRIMARY_COLOR,
-            securityTolerance: Int = SECURITY_APP_TOLERANCE,
+            securityTolerance: Int = defaultAutoLockTimeout.inWholeMilliseconds.toInt(),
         ) {
             val lastCloseAppWithTolerance = Date(lastAppClosingTime + securityTolerance)
             if (Date().after(lastCloseAppWithTolerance)) {

--- a/AppLock/src/main/java/com/infomaniak/lib/applock/LockActivity.kt
+++ b/AppLock/src/main/java/com/infomaniak/lib/applock/LockActivity.kt
@@ -38,6 +38,7 @@ import com.infomaniak.lib.applock.databinding.ActivityLockBinding
 import com.infomaniak.lib.core.utils.getAppName
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.transform
 import kotlinx.coroutines.launch
 import splitties.init.appCtx
@@ -88,6 +89,7 @@ class LockActivity : AppCompatActivity() {
                 destinationClassArgs?.let(::putExtras)
             }.also(::startActivity)
         }
+        lockedByScreenTurnedOff = false
         finish()
     }
 
@@ -160,7 +162,7 @@ class LockActivity : AppCompatActivity() {
             if (it == Lifecycle.State.RESUMED) {
                 emit(hasBiometrics() && isAppLockEnabled())
             }
-        }
+        }.distinctUntilChanged()
 
         private fun lockIfNeeded(
             targetActivity: Activity,

--- a/AppLock/src/main/java/com/infomaniak/lib/applock/LockActivity.kt
+++ b/AppLock/src/main/java/com/infomaniak/lib/applock/LockActivity.kt
@@ -196,8 +196,7 @@ class LockActivity : AppCompatActivity() {
             )
         }
 
-        //TODO: Inline into lockNow once lockAfterTimeout is removed.
-        private fun startAppLockActivity(
+        fun startAppLockActivity(
             context: Context,
             destinationClass: Class<*>,
             destinationClassArgs: Bundle? = null,

--- a/AppLock/src/main/java/com/infomaniak/lib/applock/LockActivity.kt
+++ b/AppLock/src/main/java/com/infomaniak/lib/applock/LockActivity.kt
@@ -133,15 +133,15 @@ class LockActivity : AppCompatActivity() {
             autoLockTimeout: Duration = defaultAutoLockTimeout,
             isAppLockEnabled: () -> Boolean
         ) {
-           targetActivity.lifecycleScope.launch {
-               targetActivity.shouldEnableAppLockFlow(isAppLockEnabled).collectLatest { shouldLock ->
-                   if (shouldLock) lockAppWhenNeeded(
-                       targetActivity = targetActivity,
-                       primaryColor = primaryColor,
-                       autoLockTimeout = autoLockTimeout
-                   )
-               }
-           }
+            targetActivity.lifecycleScope.launch {
+                targetActivity.shouldEnableAppLockFlow(isAppLockEnabled).collectLatest { shouldLock ->
+                    if (shouldLock) lockAppWhenNeeded(
+                        targetActivity = targetActivity,
+                        primaryColor = primaryColor,
+                        autoLockTimeout = autoLockTimeout
+                    )
+                }
+            }
         }
 
         private suspend fun lockAppWhenNeeded(
@@ -158,7 +158,7 @@ class LockActivity : AppCompatActivity() {
         }
 
         private fun ComponentActivity.shouldEnableAppLockFlow(
-            isAppLockEnabled:() -> Boolean
+            isAppLockEnabled: () -> Boolean
         ): Flow<Boolean> = lifecycle.currentStateFlow.transform {
             if (it == Lifecycle.State.RESUMED) {
                 emit(hasBiometrics() && isAppLockEnabled())


### PR DESCRIPTION
This new function encapsulates the complexity of app locking, so that the use-site becomes much simpler:
Calling the function in the target Activity's onCreate is all that's needed now.

Having logic split between onPause() and onResume() can now be a thing of the past.