### PR TITLE
fix: Block app lock hacking

### DIFF
--- a/AppLock/build.gradle
+++ b/AppLock/build.gradle
@@ -25,7 +25,6 @@ dependencies {
     implementation project(path: ':Core')
 
     implementation 'androidx.biometric:biometric-ktx:1.2.0-alpha05'
-    implementation("androidx.lifecycle:lifecycle-process:2.8.7")
     implementation("com.louiscad.splitties:splitties-appctx:3.0.0")
     implementation("com.louiscad.splitties:splitties-mainhandler:3.0.0")
     implementation("com.louiscad.splitties:splitties-systemservices:3.0.0")

--- a/AppLock/src/main/java/com/infomaniak/lib/applock/LockActivity.kt
+++ b/AppLock/src/main/java/com/infomaniak/lib/applock/LockActivity.kt
@@ -105,7 +105,7 @@ class LockActivity : AppCompatActivity() {
         private val defaultAutoLockTimeout = 1.minutes
 
         private val biometricsManager = BiometricManager.from(appCtx)
-        private const val authenticators = BIOMETRIC_WEAK or DEVICE_CREDENTIAL
+        internal const val authenticators = BIOMETRIC_WEAK or DEVICE_CREDENTIAL
 
         // On a cold start, do as if the app was left for more than the timeout.
         private var lastAppClosingTime = SystemClock.elapsedRealtime() - (defaultAutoLockTimeout.inWholeMilliseconds + 1)
@@ -213,7 +213,7 @@ class LockActivity : AppCompatActivity() {
             error("Stop using this. Calling scheduleLockIfNeeded() right from onCreate() is now enough.")
         }
 
-        private fun hasBiometrics(): Boolean {
+        fun hasBiometrics(): Boolean {
             return biometricsManager.canAuthenticate(authenticators) == BiometricManager.BIOMETRIC_SUCCESS
         }
 

--- a/AppLock/src/main/java/com/infomaniak/lib/applock/LockActivity.kt
+++ b/AppLock/src/main/java/com/infomaniak/lib/applock/LockActivity.kt
@@ -18,7 +18,6 @@
 package com.infomaniak.lib.applock
 
 import android.app.Activity
-import android.content.Context
 import android.content.Intent
 import android.os.Bundle
 import android.os.SystemClock
@@ -199,34 +198,8 @@ class LockActivity : AppCompatActivity() {
             isLocked = true
         }
 
-        @Deprecated(
-            "Stop using this. Calling scheduleLockIfNeeded() right from onCreate() is now enough.",
-            level = DeprecationLevel.ERROR
-        )
-        fun startAppLockActivity(
-            context: Context,
-            destinationClass: Class<*>,
-            destinationClassArgs: Bundle? = null,
-            primaryColor: Int = UNDEFINED_PRIMARY_COLOR,
-            shouldStartActivity: Boolean = true,
-        ) {
-            error("Stop using this. Calling scheduleLockIfNeeded() right from onCreate() is now enough.")
-        }
-
         fun hasBiometrics(): Boolean {
             return biometricsManager.canAuthenticate(authenticators) == BiometricManager.BIOMETRIC_SUCCESS
-        }
-
-        //TODO: Remove once usages (kDrive and Infomaniak Mail) are updated.
-        @Deprecated("Use scheduleLockIfNeeded(…) right from onCreate() instead.", level = DeprecationLevel.ERROR)
-        fun lockAfterTimeout(
-            context: Context,
-            destinationClass: Class<*>,
-            lastAppClosingTime: Long,
-            primaryColor: Int = UNDEFINED_PRIMARY_COLOR,
-            securityTolerance: Int = defaultAutoLockTimeout.inWholeMilliseconds.toInt(),
-        ) {
-            error("Use the new scheduleLockIfNeeded() function right from onCreate()")
         }
     }
 }

--- a/AppLock/src/main/java/com/infomaniak/lib/applock/LockActivity.kt
+++ b/AppLock/src/main/java/com/infomaniak/lib/applock/LockActivity.kt
@@ -43,7 +43,6 @@ import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.transform
 import kotlinx.coroutines.launch
 import splitties.init.appCtx
-import java.util.Date
 import kotlin.system.exitProcess
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.minutes
@@ -178,7 +177,6 @@ class LockActivity : AppCompatActivity() {
         ) {
             if (lockedByScreenTurnedOff) {
                 lockNow(targetActivity, primaryColor)
-                lockedByScreenTurnedOff = false
             } else {
                 val now = SystemClock.elapsedRealtime()
                 val timeoutExceeded = now > lastAppClosingTime + autoLockTimeout.inWholeMilliseconds

--- a/AppLock/src/main/java/com/infomaniak/lib/applock/LockActivity.kt
+++ b/AppLock/src/main/java/com/infomaniak/lib/applock/LockActivity.kt
@@ -43,7 +43,6 @@ import com.infomaniak.lib.applock.databinding.ActivityLockBinding
 import com.infomaniak.lib.core.utils.getAppName
 import kotlinx.coroutines.MainScope
 import kotlinx.coroutines.channels.Channel
-import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.*
 import kotlinx.coroutines.launch
 import splitties.init.appCtx
@@ -136,13 +135,11 @@ class LockActivity : AppCompatActivity() {
         ) {
             targetActivity.lifecycleScope.launch {
                 targetActivity.shouldEnableAppLockFlow(isAppLockEnabled).collectLatest { shouldLock ->
-                    if (shouldLock) coroutineScope {
-                        lockAppWhenNeeded(
-                            targetActivity = targetActivity,
-                            primaryColor = primaryColor,
-                            autoLockTimeout = autoLockTimeout
-                        )
-                    }
+                    if (shouldLock) lockAppWhenNeeded(
+                        targetActivity = targetActivity,
+                        primaryColor = primaryColor,
+                        autoLockTimeout = autoLockTimeout
+                    )
                 }
             }
         }

--- a/AppLock/src/main/java/com/infomaniak/lib/applock/Utils.kt
+++ b/AppLock/src/main/java/com/infomaniak/lib/applock/Utils.kt
@@ -30,15 +30,6 @@ object Utils {
 
     const val APP_LOCK_TAG = "App lock"
 
-    @Deprecated(
-        message = "Use LockActivity.hasBiometrics() instead.",
-        replaceWith = ReplaceWith(
-            "LockActivity.hasBiometrics()",
-            "com.infomaniak.lib.applock.LockActivity"
-        )
-    )
-    fun Context.isKeyguardSecure() = LockActivity.hasBiometrics()
-
     @SuppressLint("NewApi")
     fun FragmentActivity.requestCredentials(onSuccess: () -> Unit) {
         val biometricPrompt = BiometricPrompt(this,

--- a/AppLock/src/main/java/com/infomaniak/lib/applock/Utils.kt
+++ b/AppLock/src/main/java/com/infomaniak/lib/applock/Utils.kt
@@ -21,9 +21,6 @@ import android.annotation.SuppressLint
 import android.content.Context
 import android.util.Log
 import android.widget.CompoundButton
-import androidx.biometric.BiometricManager
-import androidx.biometric.BiometricManager.Authenticators.BIOMETRIC_WEAK
-import androidx.biometric.BiometricManager.Authenticators.DEVICE_CREDENTIAL
 import androidx.biometric.BiometricPrompt
 import androidx.core.content.ContextCompat
 import androidx.fragment.app.FragmentActivity
@@ -32,10 +29,15 @@ import com.infomaniak.lib.core.utils.getAppName
 object Utils {
 
     const val APP_LOCK_TAG = "App lock"
-    private const val authenticators = BIOMETRIC_WEAK or DEVICE_CREDENTIAL
 
-    fun Context.isKeyguardSecure() =
-        BiometricManager.from(this).canAuthenticate(authenticators) == BiometricManager.BIOMETRIC_SUCCESS
+    @Deprecated(
+        message = "Use LockActivity.hasBiometrics() instead.",
+        replaceWith = ReplaceWith(
+            "LockActivity.hasBiometrics()",
+            "com.infomaniak.lib.applock.LockActivity"
+        )
+    )
+    fun Context.isKeyguardSecure() = LockActivity.hasBiometrics()
 
     @SuppressLint("NewApi")
     fun FragmentActivity.requestCredentials(onSuccess: () -> Unit) {
@@ -61,7 +63,7 @@ object Utils {
 
         val promptInfo = BiometricPrompt.PromptInfo.Builder()
             .setTitle(getAppName())
-            .setAllowedAuthenticators(authenticators)
+            .setAllowedAuthenticators(LockActivity.authenticators)
             .build()
 
         biometricPrompt.authenticate(promptInfo)


### PR DESCRIPTION
1. Use SystemClock.elapsedRealtime() instead of System.currentTimeMillis(),
 so it's not possible to unlock the app by setting the time in the past.
2. Ensure the app starts locked if the system had to kill the process.
3. Ensure all tasks get the lock when screen lock triggers app lock