### PR TITLE
chore: Extract an unlock function to avoid double lock

### DIFF
--- a/AppLock/src/main/java/com/infomaniak/lib/applock/LockActivity.kt
+++ b/AppLock/src/main/java/com/infomaniak/lib/applock/LockActivity.kt
@@ -87,9 +87,7 @@ class LockActivity : AppCompatActivity() {
 
     private fun onCredentialsSuccessful() = with(navigationArgs) {
         Log.i(Utils.APP_LOCK_TAG, "success")
-        lockedByScreenTurnedOff = false
-        lastAppClosingTime = SystemClock.elapsedRealtime() // Avoid locking again immediately
-        isLocked = false
+        unlock()
         if (shouldStartActivity) {
             Intent(this@LockActivity, Class.forName(destinationClassName)).apply {
                 destinationClassArgs?.let(::putExtras)
@@ -125,6 +123,15 @@ class LockActivity : AppCompatActivity() {
                     }
                 }
             }
+        }
+
+        /**
+         * Meant to be used when enabling app lock, so the user doesn't experience a double lock.
+         */
+        fun unlock() {
+            lockedByScreenTurnedOff = false
+            lastAppClosingTime = SystemClock.elapsedRealtime() // Avoid locking again immediately
+            isLocked = false
         }
 
         fun scheduleLockIfNeeded(


### PR DESCRIPTION
This will allow client apps to call this new LockActivity.unlock() function when biometrics have been confirmed right after a request to enable the app lock.