### PR TITLE
feat: Update the limit before sending a sentry about access token errors

### DIFF
--- a/Legacy/src/main/java/com/infomaniak/lib/core/auth/TokenInterceptor.kt
+++ b/Legacy/src/main/java/com/infomaniak/lib/core/auth/TokenInterceptor.kt
@@ -1,6 +1,6 @@
 /*
  * Infomaniak Core - Android
- * Copyright (C) 2022-2024 Infomaniak Network SA
+ * Copyright (C) 2022-2025 Infomaniak Network SA
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -30,8 +30,9 @@ class TokenInterceptor(
     override fun intercept(chain: Interceptor.Chain): Response {
         var request = chain.request()
 
-        runBlocking(Dispatchers.IO) {
-            val apiToken = tokenInterceptorListener.getApiToken() ?: return@runBlocking
+        runBlocking(Dispatchers.Default) {
+            tokenInterceptorListener.getApiToken()
+        }?.let { apiToken ->
             val authorization = request.header("Authorization")
             if (apiToken.accessToken != authorization?.replaceFirst("Bearer ", "")) {
                 request = changeAccessToken(request, apiToken)

--- a/Legacy/src/main/java/com/infomaniak/lib/core/networking/AccessTokenUsageInterceptor.kt
+++ b/Legacy/src/main/java/com/infomaniak/lib/core/networking/AccessTokenUsageInterceptor.kt
@@ -67,7 +67,7 @@ class AccessTokenUsageInterceptor(
                 responseCode = responseCode,
             )
 
-            // Only report api calls that triggered an unauthorized response else log the call for future checks
+            // Only report api calls that triggered an unauthorized response else record the call for future checks
             if (responseCode != HttpsURLConnection.HTTP_UNAUTHORIZED) {
                 updateLastApiCall(currentApiCall)
                 return@launch

--- a/Legacy/src/main/java/com/infomaniak/lib/core/networking/AccessTokenUsageInterceptor.kt
+++ b/Legacy/src/main/java/com/infomaniak/lib/core/networking/AccessTokenUsageInterceptor.kt
@@ -34,7 +34,7 @@ import okhttp3.Response
 import javax.net.ssl.HttpsURLConnection
 
 private var lastReportEpoch: Long? = null
-private val mutex = Mutex()
+private val lastReportMutext = Mutex()
 
 class AccessTokenUsageInterceptor(
     private val tokenInterceptorListener: TokenInterceptorListener,
@@ -74,7 +74,7 @@ class AccessTokenUsageInterceptor(
             }
 
             // If multiple unauthorized calls are received at the same time, only send the first one to sentry
-            mutex.withLock {
+            lastReportMutext.withLock {
                 val lastReport = lastReportEpoch
                 if (lastReport != null && lastReport <= currentApiCall.date && currentApiCall.date - lastReport < TEN_SECONDS) {
                     return@launch

--- a/Legacy/src/main/java/com/infomaniak/lib/core/networking/AccessTokenUsageInterceptor.kt
+++ b/Legacy/src/main/java/com/infomaniak/lib/core/networking/AccessTokenUsageInterceptor.kt
@@ -33,7 +33,7 @@ import okhttp3.Response
 import javax.net.ssl.HttpsURLConnection
 
 private var lastReportEpoch: Long? = null
-private val lastReportMutext = Mutex()
+private val lastReportMutex = Mutex()
 
 class AccessTokenUsageInterceptor(
     private val tokenInterceptorListener: TokenInterceptorListener,
@@ -73,7 +73,7 @@ class AccessTokenUsageInterceptor(
             }
 
             // If multiple unauthorized calls are received at the same time, only send the first one to sentry
-            lastReportMutext.withLock {
+            lastReportMutex.withLock {
                 val lastReport = lastReportEpoch
                 if (lastReport != null && lastReport <= currentApiCall.date && currentApiCall.date - lastReport < TEN_SECONDS) {
                     return@launch

--- a/Legacy/src/main/java/com/infomaniak/lib/core/networking/AccessTokenUsageInterceptor.kt
+++ b/Legacy/src/main/java/com/infomaniak/lib/core/networking/AccessTokenUsageInterceptor.kt
@@ -1,6 +1,6 @@
 /*
  * Infomaniak Core - Android
- * Copyright (C) 2024 Infomaniak Network SA
+ * Copyright (C) 2024-2025 Infomaniak Network SA
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -58,10 +58,10 @@ class AccessTokenUsageInterceptor(
 
             if (previousApiCall != null &&
                 currentApiCall.accessToken == previousApiCall.accessToken &&
-                currentApiCall.date < previousApiCall.date + ONE_YEAR
+                currentApiCall.date < previousApiCall.date + SIX_MONTHS
             ) {
                 Sentry.captureMessage(
-                    "Got disconnected due to non-working access token but it's not been a year yet",
+                    "Got disconnected due to non-working access token but it's not been six months yet",
                     SentryLevel.FATAL,
                 ) { scope ->
                     scope.setExtra("Last known api call date epoch", previousApiCall.date.toString())
@@ -83,6 +83,6 @@ class AccessTokenUsageInterceptor(
     data class ApiCallRecord(val accessToken: String, val date: Long, val responseCode: Int)
 
     companion object {
-        private const val ONE_YEAR = 60 * 60 * 24 * 365L // In seconds
+        private const val SIX_MONTHS = 60 * 60 * 24 * 182L // In seconds
     }
 }

--- a/Legacy/src/main/java/com/infomaniak/lib/core/networking/AccessTokenUsageInterceptor.kt
+++ b/Legacy/src/main/java/com/infomaniak/lib/core/networking/AccessTokenUsageInterceptor.kt
@@ -91,7 +91,6 @@ class AccessTokenUsageInterceptor(
                     SentryLevel.FATAL,
                 ) { scope ->
                     scope.setExtra("Current api call date epoch", currentApiCall.date.toString())
-                    scope.setExtra("Current api call response code", currentApiCall.responseCode.toString())
                     scope.setExtra("Current api call token", formatAccessTokenForSentry(currentApiCall.accessToken))
 
                     scope.setExtra("Last known api call date epoch", previousApiCall.date.toString())

--- a/Legacy/src/main/java/com/infomaniak/lib/core/networking/AccessTokenUsageInterceptor.kt
+++ b/Legacy/src/main/java/com/infomaniak/lib/core/networking/AccessTokenUsageInterceptor.kt
@@ -74,10 +74,9 @@ class AccessTokenUsageInterceptor(
             }
 
             // If multiple unauthorized calls are received at the same time, only send the first one to sentry
-            // TODO: Check condition
             mutex.withLock {
                 val lastReport = lastReportEpoch
-                if (lastReport != null && lastReport < currentApiCall.date && currentApiCall.date - lastReport < TEN_SECONDS) {
+                if (lastReport != null && lastReport <= currentApiCall.date && currentApiCall.date - lastReport < TEN_SECONDS) {
                     return@launch
                 }
                 lastReportEpoch = currentApiCall.date


### PR DESCRIPTION
The validity limit without use as been modified from 2 months up to 6 months on the API