### PR TITLE
feat: Add ApiEnum and apiEnumValueOfOrNull helper methods

### DIFF
--- a/gradle/core.versions.toml
+++ b/gradle/core.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-androidxCore = "1.15.0"
+androidxCore = "1.13.1" # Doesn't build when bumped to 1.15.0 (Waiting SDK 35)
 composeBom = "2024.12.01"
 integrity = "1.4.0"
 junit = "4.13.2"

--- a/src/main/kotlin/com/infomaniak/core/EnumUtils.kt
+++ b/src/main/kotlin/com/infomaniak/core/EnumUtils.kt
@@ -20,3 +20,11 @@ package com.infomaniak.core
 inline fun <reified T : Enum<T>> enumValueOfOrNull(value: String?): T? {
     return value?.let { runCatching { enumValueOf<T>(it) }.getOrNull() }
 }
+
+inline fun <reified T> apiEnumValueOfOrNull(value: String?): T? where T : Enum<T>, T : ApiEnum {
+    return value?.let { runCatching { enumValues<T>().firstOrNull { it.apiValue == value } }.getOrNull() }
+}
+
+interface ApiEnum {
+    val apiValue: String
+}


### PR DESCRIPTION
Now that we write enums with PascalCase we can't always use the `enumValueOfOrNull` and base the recognition on the name of the enum value. So I added a helper method to easily get an enum instance for any enum that extends the ApiEnum interface. The interface only requires the children to implement an `apiValue` field that will be used to match the input string. The helper method is pretty similar to the existing `enumValueOfOrNull` but with a different name.

Downgrading androidxCore was necessary to use the module on Mail for the time being.