### PR TITLE
feat: Add a delegate to read and mutate an apiEnum backingfield seamlessly

### DIFF
--- a/src/main/kotlin/com/infomaniak/core/utils/EnumUtils.kt
+++ b/src/main/kotlin/com/infomaniak/core/utils/EnumUtils.kt
@@ -17,12 +17,23 @@
  */
 package com.infomaniak.core.utils
 
+import kotlin.properties.ReadWriteProperty
+import kotlin.reflect.KMutableProperty0
+import kotlin.reflect.KProperty
+
 inline fun <reified T : Enum<T>> enumValueOfOrNull(value: String?): T? {
     return value?.let { runCatching { enumValueOf<T>(it) }.getOrNull() }
 }
 
 inline fun <reified T> apiEnumValueOfOrNull(value: String?): T? where T : Enum<T>, T : ApiEnum {
     return value?.let { runCatching { enumValues<T>().firstOrNull { it.apiValue == value } }.getOrNull() }
+}
+
+inline fun <reified T> apiEnum(backingFieldProperty: KMutableProperty0<String?>): ReadWriteProperty<Any?, T?> where T : Enum<T>, T : ApiEnum {
+    return object : ReadWriteProperty<Any?, T?> {
+        override fun getValue(thisRef: Any?, property: KProperty<*>): T? = apiEnumValueOfOrNull<T>(backingFieldProperty.get())
+        override fun setValue(thisRef: Any?, property: KProperty<*>, value: T?) = backingFieldProperty.set(value?.apiValue)
+    }
 }
 
 interface ApiEnum {


### PR DESCRIPTION
Up till now, I only needed to read from an ApiEnum backing field so calling `apiEnumValueOfOrNull` everywhere was enough. But now I will also need to mutate this field so, to make it easier to manipulate I created this delegate that can be used as such:

```kt
class Example {
    private var _snoozeState: String? = null
    var snoozeState: SnoozeState? by apiEnum(::_snoozeState)
}
```