### PR TITLE
feat: Expose a canNavigate() directly accessible on any NavController

### DIFF
--- a/Legacy/src/main/java/com/infomaniak/lib/core/utils/Extensions.kt
+++ b/Legacy/src/main/java/com/infomaniak/lib/core/utils/Extensions.kt
@@ -1,6 +1,6 @@
 /*
  * Infomaniak Core - Android
- * Copyright (C) 2022-2024 Infomaniak Network SA
+ * Copyright (C) 2022-2025 Infomaniak Network SA
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -53,6 +53,7 @@ import androidx.lifecycle.DefaultLifecycleObserver
 import androidx.lifecycle.Lifecycle.Event
 import androidx.lifecycle.LifecycleEventObserver
 import androidx.lifecycle.LifecycleOwner
+import androidx.navigation.NavController
 import androidx.navigation.NavDirections
 import androidx.navigation.NavOptions
 import androidx.navigation.Navigator
@@ -362,14 +363,18 @@ fun ImageView.loadAvatar(
 }
 
 fun Fragment.canNavigate(currentClassName: String? = null): Boolean {
-    val className = currentClassName ?: when (val currentDestination = findNavController().currentDestination) {
+    return findNavController().canNavigate(allowedStartingClassName = javaClass.name, currentClassName)
+}
+
+fun NavController.canNavigate(allowedStartingClassName: String, currentClassName: String? = null): Boolean {
+    val className = currentClassName ?: when (val currentDestination = currentDestination) {
         is FragmentNavigator.Destination -> currentDestination.className
         is DialogFragmentNavigator.Destination -> currentDestination.className
-        null -> javaClass.name
+        null -> allowedStartingClassName
         else -> null
     }
 
-    return javaClass.name == className
+    return allowedStartingClassName == className
 }
 
 fun Fragment.safeNavigate(directions: NavDirections, currentClassName: String? = null) = with(findNavController()) {


### PR DESCRIPTION
For the snooze feature, there's a situation where I'm in a BottomSheet, I show an AlertDialog and close the BottomSheet, and when the user clicks on the positive button, I need to initiate a navigation.

When the user clicks on the positive button, since the BottomSheet is no more, calling `findNavController()` on the BottomSheet that's gone crashes because it can't find any NavController.

But the `navController` can be "found" before closing the BottomSheet and displaying the AlertDialog, and therefore when the user clicks on the positive button, the reste of the navigation can be executed on the already "found" `navController`.

For this reason, I need to expose a `canNavigate()` method that directly works with a NavController.