### PR TITLE
feat: Deprecate old safe navigation methods and introduce new ones

### DIFF
--- a/FragmentNavigation/build.gradle.kts
+++ b/FragmentNavigation/build.gradle.kts
@@ -1,0 +1,39 @@
+plugins {
+    id("com.android.library")
+    alias(core.plugins.kotlin.android)
+}
+
+val coreCompileSdk: Int by rootProject.extra
+val coreMinSdk: Int by rootProject.extra
+val javaVersion: JavaVersion by rootProject.extra
+
+android {
+    namespace = "com.infomaniak.core.fragmentnavigation"
+    compileSdk = coreCompileSdk
+
+    defaultConfig {
+        minSdk = coreMinSdk
+
+        testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
+        consumerProguardFiles("consumer-rules.pro")
+    }
+
+    buildTypes {
+        release {
+            isMinifyEnabled = false
+            proguardFiles(getDefaultProguardFile("proguard-android-optimize.txt"), "proguard-rules.pro")
+        }
+    }
+    compileOptions {
+        sourceCompatibility = javaVersion
+        targetCompatibility = javaVersion
+    }
+    kotlinOptions {
+        jvmTarget = javaVersion.toString()
+    }
+}
+
+dependencies {
+    implementation(core.androidx.core.ktx)
+    implementation(core.navigation.fragment.ktx)
+}

--- a/FragmentNavigation/proguard-rules.pro
+++ b/FragmentNavigation/proguard-rules.pro
@@ -1,0 +1,21 @@
+# Add project specific ProGuard rules here.
+# You can control the set of applied configuration files using the
+# proguardFiles setting in build.gradle.
+#
+# For more details, see
+#   http://developer.android.com/guide/developing/tools/proguard.html
+
+# If your project uses WebView with JS, uncomment the following
+# and specify the fully qualified class name to the JavaScript interface
+# class:
+#-keepclassmembers class fqcn.of.javascript.interface.for.webview {
+#   public *;
+#}
+
+# Uncomment this to preserve the line number information for
+# debugging stack traces.
+#-keepattributes SourceFile,LineNumberTable
+
+# If you keep the line number information, uncomment this to
+# hide the original source file name.
+#-renamesourcefileattribute SourceFile

--- a/FragmentNavigation/src/main/java/com/infomaniak/core/fragmentnavigation/FragmentNavigationExt.kt
+++ b/FragmentNavigation/src/main/java/com/infomaniak/core/fragmentnavigation/FragmentNavigationExt.kt
@@ -44,7 +44,8 @@ fun NavController.isAtInitialDestination(allowedInitialClassName: String): Boole
 }
 
 fun Fragment.safelyNavigate(directions: NavDirections) = findNavController().let { navController ->
-    // Checks if the NavDirections still needs to be executed because we can find its actionId in currentDestination
+    // Checks whether we're currently at the destination where the action was defined from. NavDirections still needs to be
+    // executed when we can find its actionId inside currentDestination.
     if (navController.currentDestination?.getAction(directions.actionId) != null) {
         navController.navigate(directions)
     }

--- a/FragmentNavigation/src/main/java/com/infomaniak/core/fragmentnavigation/FragmentNavigationExt.kt
+++ b/FragmentNavigation/src/main/java/com/infomaniak/core/fragmentnavigation/FragmentNavigationExt.kt
@@ -43,12 +43,10 @@ fun NavController.isAtInitialDestination(allowedInitialClassName: String): Boole
     return allowedInitialClassName == currentlyAtClassName
 }
 
-fun Fragment.safelyNavigate(directions: NavDirections) = findNavController().let { navController ->
-    // Checks whether we're currently at the destination where the action was defined from. NavDirections still needs to be
-    // executed when we can find its actionId inside currentDestination.
-    if (navController.currentDestination?.getAction(directions.actionId) != null) {
-        navController.navigate(directions)
-    }
+fun Fragment.safelyNavigate(directions: NavDirections) = with(findNavController()) {
+    // Checks whether we're currently at the destination where the action was defined from.
+    // NavDirections still needs to be executed when we can find its actionId inside currentDestination.
+    if (currentDestination?.getAction(directions.actionId) != null) navigate(directions)
 }
 
 fun Fragment.safelyNavigate(

--- a/FragmentNavigation/src/main/java/com/infomaniak/core/fragmentnavigation/FragmentNavigationExt.kt
+++ b/FragmentNavigation/src/main/java/com/infomaniak/core/fragmentnavigation/FragmentNavigationExt.kt
@@ -1,0 +1,61 @@
+/*
+ * Infomaniak Core - Android
+ * Copyright (C) 2025 Infomaniak Network SA
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.infomaniak.core.fragmentnavigation
+
+import android.os.Bundle
+import androidx.annotation.IdRes
+import androidx.fragment.app.Fragment
+import androidx.navigation.NavController
+import androidx.navigation.NavDirections
+import androidx.navigation.NavOptions
+import androidx.navigation.Navigator
+import androidx.navigation.fragment.DialogFragmentNavigator
+import androidx.navigation.fragment.FragmentNavigator
+import androidx.navigation.fragment.findNavController
+
+fun Fragment.isAtInitialDestination(substituteClassName: String? = null): Boolean {
+    return findNavController().isAtInitialDestination(allowedInitialClassName = substituteClassName ?: javaClass.name)
+}
+
+fun NavController.isAtInitialDestination(allowedInitialClassName: String): Boolean {
+    val currentlyAtClassName = when (val currentlyAtDestination = currentDestination) {
+        is FragmentNavigator.Destination -> currentlyAtDestination.className
+        is DialogFragmentNavigator.Destination -> currentlyAtDestination.className
+        null -> return true
+        else -> return false
+    }
+
+    return allowedInitialClassName == currentlyAtClassName
+}
+
+fun Fragment.safelyNavigate(directions: NavDirections) = findNavController().let { navController ->
+    // Checks if the NavDirections still needs to be executed because we can find its actionId in currentDestination
+    if (navController.currentDestination?.getAction(directions.actionId) != null) {
+        navController.navigate(directions)
+    }
+}
+
+fun Fragment.safelyNavigate(
+    @IdRes resId: Int,
+    args: Bundle? = null,
+    navOptions: NavOptions? = null,
+    navigatorExtras: Navigator.Extras? = null,
+    substituteClassName: String? = null,
+) {
+    if (isAtInitialDestination(substituteClassName)) findNavController().navigate(resId, args, navOptions, navigatorExtras)
+}

--- a/Legacy/src/main/java/com/infomaniak/lib/core/utils/Extensions.kt
+++ b/Legacy/src/main/java/com/infomaniak/lib/core/utils/Extensions.kt
@@ -369,8 +369,8 @@ fun ImageView.loadAvatar(
         imports = ["com.infomaniak.core.fragmentnavigation.isAtInitialDestination"],
     )
 )
-@Suppress("DEPRECATION")
 fun Fragment.canNavigate(currentClassName: String? = null): Boolean {
+    @Suppress("DEPRECATION")
     return findNavController().canNavigate(allowedStartingClassName = javaClass.name, currentClassName)
 }
 
@@ -399,8 +399,8 @@ fun NavController.canNavigate(allowedStartingClassName: String, currentClassName
         imports = ["com.infomaniak.core.fragmentnavigation.safelyNavigate"],
     )
 )
-@Suppress("DEPRECATION")
 fun Fragment.safeNavigate(directions: NavDirections, currentClassName: String? = null) = with(findNavController()) {
+    @Suppress("DEPRECATION")
     if (canNavigate(currentClassName) && currentDestination?.getAction(directions.actionId) != null) {
         navigate(directions)
     }
@@ -413,7 +413,6 @@ fun Fragment.safeNavigate(directions: NavDirections, currentClassName: String? =
         imports = ["com.infomaniak.core.fragmentnavigation.safelyNavigate"],
     )
 )
-@Suppress("DEPRECATION")
 fun Fragment.safeNavigate(
     @IdRes resId: Int,
     args: Bundle? = null,
@@ -421,6 +420,7 @@ fun Fragment.safeNavigate(
     navigatorExtras: Navigator.Extras? = null,
     currentClassName: String? = null,
 ) {
+    @Suppress("DEPRECATION")
     if (canNavigate(currentClassName)) findNavController().navigate(resId, args, navOptions, navigatorExtras)
 }
 

--- a/Legacy/src/main/java/com/infomaniak/lib/core/utils/Extensions.kt
+++ b/Legacy/src/main/java/com/infomaniak/lib/core/utils/Extensions.kt
@@ -362,10 +362,25 @@ fun ImageView.loadAvatar(
     }
 }
 
+@Deprecated(
+    "Providing a currentClassName will bypass any form of verification. Use the new method exposed through the FragmentNavigation module instead",
+    ReplaceWith(
+        expression = "isAtInitialDestination()",
+        imports = ["com.infomaniak.core.fragmentnavigation.isAtInitialDestination"],
+    )
+)
+@Suppress("DEPRECATION")
 fun Fragment.canNavigate(currentClassName: String? = null): Boolean {
     return findNavController().canNavigate(allowedStartingClassName = javaClass.name, currentClassName)
 }
 
+@Deprecated(
+    "Providing a currentClassName will bypass any form of verification. Use the new method exposed through the FragmentNavigation module instead",
+    ReplaceWith(
+        expression = "isAtInitialDestination(allowedStartingClassName)",
+        imports = ["com.infomaniak.core.fragmentnavigation.isAtInitialDestination"],
+    )
+)
 fun NavController.canNavigate(allowedStartingClassName: String, currentClassName: String? = null): Boolean {
     val className = currentClassName ?: when (val currentDestination = currentDestination) {
         is FragmentNavigator.Destination -> currentDestination.className
@@ -377,12 +392,28 @@ fun NavController.canNavigate(allowedStartingClassName: String, currentClassName
     return allowedStartingClassName == className
 }
 
+@Deprecated(
+    "Providing a currentClassName won't have any impact",
+    ReplaceWith(
+        expression = "safelyNavigate(directions)",
+        imports = ["com.infomaniak.core.fragmentnavigation.safelyNavigate"],
+    )
+)
+@Suppress("DEPRECATION")
 fun Fragment.safeNavigate(directions: NavDirections, currentClassName: String? = null) = with(findNavController()) {
     if (canNavigate(currentClassName) && currentDestination?.getAction(directions.actionId) != null) {
         navigate(directions)
     }
 }
 
+@Deprecated(
+    "Providing a currentClassName will bypass any form of verification. Use the new method exposed through the FragmentNavigation module instead",
+    ReplaceWith(
+        expression = "safelyNavigate(resId, args, navOptions, navigatorExtras, currentClassName)",
+        imports = ["com.infomaniak.core.fragmentnavigation.safelyNavigate"],
+    )
+)
+@Suppress("DEPRECATION")
 fun Fragment.safeNavigate(
     @IdRes resId: Int,
     args: Bundle? = null,

--- a/Legacy/src/main/java/com/infomaniak/lib/core/utils/Extensions.kt
+++ b/Legacy/src/main/java/com/infomaniak/lib/core/utils/Extensions.kt
@@ -393,7 +393,7 @@ fun NavController.canNavigate(allowedStartingClassName: String, currentClassName
 }
 
 @Deprecated(
-    "Providing a currentClassName won't have any impact",
+    "Providing a currentClassName won't have any impact. Use the new method exposed through the FragmentNavigation module instead",
     ReplaceWith(
         expression = "safelyNavigate(directions)",
         imports = ["com.infomaniak.core.fragmentnavigation.safelyNavigate"],


### PR DESCRIPTION
Old navigation methods were bugged as described in the deprecation messages. This PR deprecates them and introduces new fixed ones in the new core. 

We changed the name to be able to have different signatures and so we can still use the deprecated version alongside the new version in the same file