### PR TITLE
fix: Prevent crash occurring on some Xiaomi and Redmi devices

### DIFF
--- a/src/main/kotlin/com/infomaniak/core/DownloadManager.kt
+++ b/src/main/kotlin/com/infomaniak/core/DownloadManager.kt
@@ -79,7 +79,15 @@ sealed interface DownloadStatus {
 }
 
 suspend fun DownloadManager.startDownloadingFile(request: DownloadManager.Request): UniqueDownloadId? {
-    val uniqueDownloadId = Dispatchers.IO { enqueue(request) }
+    val uniqueDownloadId = Dispatchers.IO {
+        try {
+            enqueue(request)
+        } catch (_: NullPointerException) {
+            // enqueue is supposed to return -1 in case the operation fails,
+            // but on Xiaomi and Redmi devices, it throws NPEs instead…
+            -1L
+        }
+    }
     return if (uniqueDownloadId == -1L) null else UniqueDownloadId(uniqueDownloadId)
 }
 


### PR DESCRIPTION
DownloadManager.enqueue is supposed to return -1 if the operation fails, but on those devices, it throws a NullPointerException instead, so we catch it.