### PR TITLE
feat: Deprecate ApiResponse.translatedError

### DIFF
--- a/Legacy/src/main/java/com/infomaniak/lib/core/api/ApiController.kt
+++ b/Legacy/src/main/java/com/infomaniak/lib/core/api/ApiController.kt
@@ -192,7 +192,7 @@ object ApiController {
                             scope.setExtra("bodyResponse", bodyResponse)
                         }
                         createErrorResponse(
-                            TranslatedInternalErrorCode.ServerError,
+                            TranslatedInternalErrorCode.UnknownError,
                             InternalErrorPayload(ServerErrorException(bodyResponse), useKotlinxSerialization, bodyResponse),
                             buildErrorResult = buildErrorResult,
                         )
@@ -283,7 +283,6 @@ object ApiController {
     ) : ErrorCode.Translated {
         NoConnection("no_connection", R.string.noConnection),
         ConnectionError("connection_error", R.string.connectionError),
-        ServerError("server_error", R.string.serverError),
         UnknownError("an_error_has_occurred", R.string.anErrorHasOccurred),
     }
 

--- a/Legacy/src/main/java/com/infomaniak/lib/core/api/ApiController.kt
+++ b/Legacy/src/main/java/com/infomaniak/lib/core/api/ApiController.kt
@@ -17,7 +17,6 @@
  */
 package com.infomaniak.lib.core.api
 
-import androidx.annotation.StringRes
 import com.google.gson.Gson
 import com.google.gson.GsonBuilder
 import com.google.gson.JsonParser
@@ -192,7 +191,7 @@ object ApiController {
                             scope.setExtra("bodyResponse", bodyResponse)
                         }
                         createErrorResponse(
-                            TranslatedInternalErrorCode.UnknownError,
+                            InternalTranslatedErrorCode.UnknownError,
                             InternalErrorPayload(ServerErrorException(bodyResponse), useKotlinxSerialization, bodyResponse),
                             buildErrorResult = buildErrorResult,
                         )
@@ -203,7 +202,7 @@ object ApiController {
             }
         } catch (refreshTokenException: RefreshTokenException) {
             refreshTokenException.printStackTrace()
-            return createErrorResponse(TranslatedInternalErrorCode.UnknownError, buildErrorResult = buildErrorResult)
+            return createErrorResponse(InternalTranslatedErrorCode.UnknownError, buildErrorResult = buildErrorResult)
         } catch (exception: Exception) {
             exception.printStackTrace()
 
@@ -218,7 +217,7 @@ object ApiController {
                 }
 
                 createErrorResponse(
-                    TranslatedInternalErrorCode.UnknownError,
+                    InternalTranslatedErrorCode.UnknownError,
                     InternalErrorPayload(exception, useKotlinxSerialization, bodyResponse),
                     buildErrorResult = buildErrorResult,
                 )
@@ -247,13 +246,13 @@ object ApiController {
         noNetwork: Boolean = false,
         noinline buildErrorResult: ((apiError: ApiError?, translatedErrorRes: Int) -> T)?,
     ): T = createErrorResponse<T>(
-        if (noNetwork) TranslatedInternalErrorCode.NoConnection else TranslatedInternalErrorCode.ConnectionError,
+        if (noNetwork) InternalTranslatedErrorCode.NoConnection else InternalTranslatedErrorCode.ConnectionError,
         InternalErrorPayload(NetworkException()),
         buildErrorResult = buildErrorResult,
     )
 
     inline fun <reified T> createErrorResponse(
-        internalErrorCode: TranslatedInternalErrorCode,
+        internalErrorCode: InternalTranslatedErrorCode,
         payload: InternalErrorPayload? = null,
         noinline buildErrorResult: ((apiError: ApiError?, translatedErrorRes: Int) -> T)?,
     ): T {
@@ -277,16 +276,7 @@ object ApiController {
         val bodyResponse: String? = null,
     )
 
-    enum class TranslatedInternalErrorCode(
-        override val code: String,
-        @StringRes override val translateRes: Int,
-    ) : ErrorCode.Translated {
-        NoConnection("no_connection", R.string.noConnection),
-        ConnectionError("connection_error", R.string.connectionError),
-        UnknownError("an_error_has_occurred", R.string.anErrorHasOccurred),
-    }
-
-    fun ErrorCode.toApiError(payload: InternalErrorPayload?): ApiError {
+    fun ErrorCode.toApiError(payload: InternalErrorPayload? = null): ApiError {
         val useKotlinxSerialization = payload?.useKotlinxSerialization
         return ApiError(
             code = code,

--- a/Legacy/src/main/java/com/infomaniak/lib/core/api/ApiController.kt
+++ b/Legacy/src/main/java/com/infomaniak/lib/core/api/ApiController.kt
@@ -192,8 +192,12 @@ object ApiController {
                             scope.setExtra("bodyResponse", bodyResponse)
                         }
                         createErrorResponse(
-                            apiError = createApiError(useKotlinxSerialization, bodyResponse, ServerErrorException(bodyResponse)),
-                            translatedError = R.string.serverError,
+                            apiError = TranslatedInternalErrorCode.ServerError.toApiError(
+                                useKotlinxSerialization,
+                                bodyResponse,
+                                ServerErrorException(bodyResponse),
+                            ),
+                            translatedError = TranslatedInternalErrorCode.ServerError.translateRes,
                             buildErrorResult = buildErrorResult,
                         )
                     }
@@ -260,7 +264,13 @@ object ApiController {
         )
     }
 
-    fun createApiError(useKotlinxSerialization: Boolean, bodyResponse: String, exception: Exception) = ApiError(
+    fun createApiError(
+        useKotlinxSerialization: Boolean,
+        bodyResponse: String,
+        exception: Exception,
+        code: String? = null,
+    ) = ApiError(
+        code = code,
         contextJson = if (useKotlinxSerialization) bodyResponse.bodyResponseToJson() else null,
         contextGson = when {
             useKotlinxSerialization -> null
@@ -291,7 +301,14 @@ object ApiController {
     ) : ErrorCode.Translated {
         NoConnection("no_connection", R.string.noConnection),
         ConnectionError("connection_error", R.string.connectionError),
+        ServerError("server_error", R.string.serverError),
     }
 
     fun ErrorCode.toApiError(exception: Exception): ApiError = ApiError(code = code, exception = exception)
+
+    fun ErrorCode.toApiError(
+        useKotlinxSerialization: Boolean,
+        bodyResponse: String,
+        exception: Exception,
+    ): ApiError = createApiError(useKotlinxSerialization, bodyResponse, exception, code)
 }

--- a/Legacy/src/main/java/com/infomaniak/lib/core/api/ApiController.kt
+++ b/Legacy/src/main/java/com/infomaniak/lib/core/api/ApiController.kt
@@ -23,7 +23,6 @@ import com.google.gson.JsonParser
 import com.google.gson.reflect.TypeToken
 import com.infomaniak.lib.core.BuildConfig.LOGIN_ENDPOINT_URL
 import com.infomaniak.lib.core.InfomaniakCore
-import com.infomaniak.lib.core.R
 import com.infomaniak.lib.core.auth.TokenInterceptorListener
 import com.infomaniak.lib.core.models.ApiError
 import com.infomaniak.lib.core.models.ApiResponse
@@ -232,7 +231,8 @@ object ApiController {
         }
 
         if (apiResponse is ApiResponse<*> && apiResponse.result == ERROR) {
-            apiResponse.translatedError = R.string.anErrorHasOccurred
+            apiResponse.translatedError = InternalTranslatedErrorCode.UnknownError.translateRes
+            apiResponse.error = InternalTranslatedErrorCode.UnknownError.toApiError()
         }
 
         return apiResponse

--- a/Legacy/src/main/java/com/infomaniak/lib/core/api/ApiController.kt
+++ b/Legacy/src/main/java/com/infomaniak/lib/core/api/ApiController.kt
@@ -30,7 +30,7 @@ import com.infomaniak.lib.core.models.ApiResponseStatus.ERROR
 import com.infomaniak.lib.core.networking.HttpClient
 import com.infomaniak.lib.core.networking.HttpUtils
 import com.infomaniak.lib.core.utils.CustomDateTypeAdapter
-import com.infomaniak.lib.core.utils.ErrorCode
+import com.infomaniak.lib.core.utils.ErrorCodeTranslated
 import com.infomaniak.lib.core.utils.isNetworkException
 import com.infomaniak.lib.core.utils.isSerializationException
 import com.infomaniak.lib.login.ApiToken
@@ -277,7 +277,7 @@ object ApiController {
         val bodyResponse: String? = null,
     )
 
-    fun ErrorCode.toApiError(payload: InternalErrorPayload? = null): ApiError {
+    fun ErrorCodeTranslated.toApiError(payload: InternalErrorPayload? = null): ApiError {
         val useKotlinxSerialization = payload?.useKotlinxSerialization
         return ApiError(
             code = code,

--- a/Legacy/src/main/java/com/infomaniak/lib/core/api/ApiController.kt
+++ b/Legacy/src/main/java/com/infomaniak/lib/core/api/ApiController.kt
@@ -231,6 +231,7 @@ object ApiController {
         }
 
         if (apiResponse is ApiResponse<*> && apiResponse.result == ERROR) {
+            @Suppress("DEPRECATION")
             apiResponse.translatedError = InternalTranslatedErrorCode.UnknownError.translateRes
             apiResponse.error = InternalTranslatedErrorCode.UnknownError.toApiError()
         }

--- a/Legacy/src/main/java/com/infomaniak/lib/core/api/ApiController.kt
+++ b/Legacy/src/main/java/com/infomaniak/lib/core/api/ApiController.kt
@@ -207,7 +207,11 @@ object ApiController {
             }
         } catch (refreshTokenException: RefreshTokenException) {
             refreshTokenException.printStackTrace()
-            return createErrorResponse(translatedError = R.string.anErrorHasOccurred, buildErrorResult = buildErrorResult)
+            return createErrorResponse(
+                translatedError = TranslatedInternalErrorCode.UnknownError.translateRes,
+                apiError = TranslatedInternalErrorCode.UnknownError.toApiError(),
+                buildErrorResult = buildErrorResult,
+            )
         } catch (exception: Exception) {
             exception.printStackTrace()
 
@@ -222,8 +226,12 @@ object ApiController {
                 }
 
                 createErrorResponse(
-                    translatedError = R.string.anErrorHasOccurred,
-                    apiError = createApiError(useKotlinxSerialization, bodyResponse, exception = exception),
+                    translatedError = TranslatedInternalErrorCode.UnknownError.translateRes,
+                    apiError = TranslatedInternalErrorCode.UnknownError.toApiError(
+                        useKotlinxSerialization,
+                        bodyResponse,
+                        exception,
+                    ),
                     buildErrorResult = buildErrorResult,
                 )
             }
@@ -302,9 +310,10 @@ object ApiController {
         NoConnection("no_connection", R.string.noConnection),
         ConnectionError("connection_error", R.string.connectionError),
         ServerError("server_error", R.string.serverError),
+        UnknownError("an_error_has_occurred", R.string.anErrorHasOccurred),
     }
 
-    fun ErrorCode.toApiError(exception: Exception): ApiError = ApiError(code = code, exception = exception)
+    fun ErrorCode.toApiError(exception: Exception? = null): ApiError = ApiError(code = code, exception = exception)
 
     fun ErrorCode.toApiError(
         useKotlinxSerialization: Boolean,

--- a/Legacy/src/main/java/com/infomaniak/lib/core/api/InternalTranslatedErrorCode.kt
+++ b/Legacy/src/main/java/com/infomaniak/lib/core/api/InternalTranslatedErrorCode.kt
@@ -1,0 +1,32 @@
+/*
+ * Infomaniak Core - Android
+ * Copyright (C) 2025 Infomaniak Network SA
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.infomaniak.lib.core.api
+
+import androidx.annotation.StringRes
+import com.infomaniak.lib.core.R
+import com.infomaniak.lib.core.utils.ErrorCode
+
+enum class InternalTranslatedErrorCode(
+    override val code: String,
+    @StringRes override val translateRes: Int,
+) : ErrorCode.Translated {
+    NoConnection("no_connection", R.string.noConnection),
+    ConnectionError("connection_error", R.string.connectionError),
+    UnknownError("an_error_has_occurred", R.string.anErrorHasOccurred),
+    UserAlreadyPresent("user_already_present", R.string.errorUserAlreadyPresent),
+}

--- a/Legacy/src/main/java/com/infomaniak/lib/core/api/InternalTranslatedErrorCode.kt
+++ b/Legacy/src/main/java/com/infomaniak/lib/core/api/InternalTranslatedErrorCode.kt
@@ -19,12 +19,12 @@ package com.infomaniak.lib.core.api
 
 import androidx.annotation.StringRes
 import com.infomaniak.lib.core.R
-import com.infomaniak.lib.core.utils.ErrorCode
+import com.infomaniak.lib.core.utils.ErrorCodeTranslated
 
 enum class InternalTranslatedErrorCode(
     override val code: String,
     @StringRes override val translateRes: Int,
-) : ErrorCode.Translated {
+) : ErrorCodeTranslated {
     NoConnection("no_connection", R.string.noConnection),
     ConnectionError("connection_error", R.string.connectionError),
     UnknownError("an_error_has_occurred", R.string.anErrorHasOccurred),

--- a/Legacy/src/main/java/com/infomaniak/lib/core/models/ApiResponse.kt
+++ b/Legacy/src/main/java/com/infomaniak/lib/core/models/ApiResponse.kt
@@ -27,7 +27,7 @@ open class ApiResponse<T>(
     val result: ApiResponseStatus = ApiResponseStatus.UNKNOWN,
     val data: @RawValue T? = null,
     val uri: String? = null,
-    val error: ApiError? = null,
+    var error: ApiError? = null,
     val page: Int = 0,
     val pages: Int = 0,
     @SerialName("response_at")

--- a/Legacy/src/main/java/com/infomaniak/lib/core/models/ApiResponse.kt
+++ b/Legacy/src/main/java/com/infomaniak/lib/core/models/ApiResponse.kt
@@ -1,6 +1,6 @@
 /*
  * Infomaniak Core - Android
- * Copyright (C) 2022-2024 Infomaniak Network SA
+ * Copyright (C) 2022-2025 Infomaniak Network SA
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -34,6 +34,7 @@ open class ApiResponse<T>(
     @SerializedName("response_at")
     val responseAt: Long = 0,
     val total: Int = 0,
+    @Deprecated("(╯°□°)╯︵ ┻━┻") // TODO
     var translatedError: Int = 0,
     @SerialName("items_per_page")
     @SerializedName("items_per_page")

--- a/Legacy/src/main/java/com/infomaniak/lib/core/models/ApiResponse.kt
+++ b/Legacy/src/main/java/com/infomaniak/lib/core/models/ApiResponse.kt
@@ -34,7 +34,11 @@ open class ApiResponse<T>(
     @SerializedName("response_at")
     val responseAt: Long = 0,
     val total: Int = 0,
-    @Deprecated("(╯°□°)╯︵ ┻━┻") // TODO
+    @Deprecated(
+        "translatedError doesn't take into account project specific translated errors specified through " +
+                "InfomaniakCore.apiErrorCodes. Use translateError() instead",
+        ReplaceWith("translateError()", "com.infomaniak.lib.core.utils.ApiErrorCode.Companion.translateError"),
+    )
     var translatedError: Int = 0,
     @SerialName("items_per_page")
     @SerializedName("items_per_page")

--- a/Legacy/src/main/java/com/infomaniak/lib/core/utils/ApiErrorCode.kt
+++ b/Legacy/src/main/java/com/infomaniak/lib/core/utils/ApiErrorCode.kt
@@ -22,21 +22,18 @@ import com.infomaniak.lib.core.InfomaniakCore
 import com.infomaniak.lib.core.api.InternalTranslatedErrorCode
 import com.infomaniak.lib.core.models.ApiResponse
 
-interface ErrorCode {
+interface ErrorCodeTranslated {
     val code: String
-
-    interface Translated : ErrorCode {
-        @get:StringRes
-        val translateRes: Int
-    }
+    @get:StringRes
+    val translateRes: Int
 }
 
-data class ApiErrorCode(override val code: String, @StringRes override val translateRes: Int) : ErrorCode.Translated {
+data class ApiErrorCode(override val code: String, @StringRes override val translateRes: Int) : ErrorCodeTranslated {
     companion object {
         @StringRes
         fun <T> ApiResponse<T>.translateError(): Int = formatError().translateRes
 
-        fun <T> ApiResponse<T>.formatError(): ErrorCode.Translated {
+        fun <T> ApiResponse<T>.formatError(): ErrorCodeTranslated {
             val errorCode = error?.code
             return if (errorCode == null) {
                 InternalTranslatedErrorCode.UnknownError

--- a/Legacy/src/main/java/com/infomaniak/lib/core/utils/ApiErrorCode.kt
+++ b/Legacy/src/main/java/com/infomaniak/lib/core/utils/ApiErrorCode.kt
@@ -19,7 +19,6 @@ package com.infomaniak.lib.core.utils
 
 import androidx.annotation.StringRes
 import com.infomaniak.lib.core.InfomaniakCore
-import com.infomaniak.lib.core.R
 import com.infomaniak.lib.core.api.ApiController.TranslatedInternalErrorCode
 import com.infomaniak.lib.core.models.ApiResponse
 
@@ -34,24 +33,18 @@ interface ErrorCode {
 }
 
 data class ApiErrorCode(override val code: String, @StringRes override val translateRes: Int) : ErrorCode.Translated {
-
     companion object {
-
-        const val AN_ERROR_HAS_OCCURRED = "an_error_has_occured"
-
-        private val defaultApiErrorCode = ApiErrorCode(AN_ERROR_HAS_OCCURRED, R.string.anErrorHasOccurred)
-
         @StringRes
         fun <T> ApiResponse<T>.translateError(): Int = formatError().translateRes
 
         fun <T> ApiResponse<T>.formatError(): ErrorCode.Translated {
             val errorCode = error?.code
             return if (errorCode == null) {
-                defaultApiErrorCode
+                TranslatedInternalErrorCode.UnknownError
             } else {
                 InfomaniakCore.apiErrorCodes?.firstOrNull { it.code.equals(errorCode, ignoreCase = true) }
                     ?: TranslatedInternalErrorCode.entries.firstOrNull { it.code.equals(errorCode, ignoreCase = true) }
-                    ?: defaultApiErrorCode
+                    ?: TranslatedInternalErrorCode.UnknownError
             }
         }
     }

--- a/Legacy/src/main/java/com/infomaniak/lib/core/utils/ApiErrorCode.kt
+++ b/Legacy/src/main/java/com/infomaniak/lib/core/utils/ApiErrorCode.kt
@@ -19,7 +19,7 @@ package com.infomaniak.lib.core.utils
 
 import androidx.annotation.StringRes
 import com.infomaniak.lib.core.InfomaniakCore
-import com.infomaniak.lib.core.api.ApiController.TranslatedInternalErrorCode
+import com.infomaniak.lib.core.api.InternalTranslatedErrorCode
 import com.infomaniak.lib.core.models.ApiResponse
 
 interface ErrorCode {
@@ -39,11 +39,11 @@ data class ApiErrorCode(override val code: String, @StringRes override val trans
         fun <T> ApiResponse<T>.formatError(): ErrorCode.Translated {
             val errorCode = error?.code
             return if (errorCode == null) {
-                TranslatedInternalErrorCode.UnknownError
+                InternalTranslatedErrorCode.UnknownError
             } else {
                 InfomaniakCore.apiErrorCodes?.firstOrNull { it.code.equals(errorCode, ignoreCase = true) }
-                    ?: TranslatedInternalErrorCode.entries.firstOrNull { it.code.equals(errorCode, ignoreCase = true) }
-                    ?: TranslatedInternalErrorCode.UnknownError
+                    ?: InternalTranslatedErrorCode.entries.firstOrNull { it.code.equals(errorCode, ignoreCase = true) }
+                    ?: InternalTranslatedErrorCode.UnknownError
             }
         }
     }

--- a/Legacy/src/main/java/com/infomaniak/lib/core/utils/ApiErrorCode.kt
+++ b/Legacy/src/main/java/com/infomaniak/lib/core/utils/ApiErrorCode.kt
@@ -26,7 +26,6 @@ interface ErrorCode {
     val code: String
 
     interface Translated : ErrorCode {
-        override val code: String
         @get:StringRes
         val translateRes: Int
     }

--- a/Legacy/src/main/java/com/infomaniak/lib/core/utils/ApiErrorCode.kt
+++ b/Legacy/src/main/java/com/infomaniak/lib/core/utils/ApiErrorCode.kt
@@ -1,6 +1,6 @@
 /*
  * Infomaniak Core - Android
- * Copyright (C) 2023-2024 Infomaniak Network SA
+ * Copyright (C) 2023-2025 Infomaniak Network SA
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -20,9 +20,20 @@ package com.infomaniak.lib.core.utils
 import androidx.annotation.StringRes
 import com.infomaniak.lib.core.InfomaniakCore
 import com.infomaniak.lib.core.R
+import com.infomaniak.lib.core.api.ApiController.TranslatedInternalErrorCode
 import com.infomaniak.lib.core.models.ApiResponse
 
-data class ApiErrorCode(val code: String, @StringRes val translateRes: Int) {
+interface ErrorCode {
+    val code: String
+
+    interface Translated : ErrorCode {
+        override val code: String
+        @get:StringRes
+        val translateRes: Int
+    }
+}
+
+data class ApiErrorCode(override val code: String, @StringRes override val translateRes: Int) : ErrorCode.Translated {
 
     companion object {
 
@@ -33,12 +44,14 @@ data class ApiErrorCode(val code: String, @StringRes val translateRes: Int) {
         @StringRes
         fun <T> ApiResponse<T>.translateError(): Int = formatError().translateRes
 
-        fun <T> ApiResponse<T>.formatError(): ApiErrorCode {
+        fun <T> ApiResponse<T>.formatError(): ErrorCode.Translated {
             val errorCode = error?.code
             return if (errorCode == null) {
                 defaultApiErrorCode
             } else {
-                InfomaniakCore.apiErrorCodes?.firstOrNull { it.code.equals(errorCode, ignoreCase = true) } ?: defaultApiErrorCode
+                InfomaniakCore.apiErrorCodes?.firstOrNull { it.code.equals(errorCode, ignoreCase = true) }
+                    ?: TranslatedInternalErrorCode.entries.firstOrNull { it.code.equals(errorCode, ignoreCase = true) }
+                    ?: defaultApiErrorCode
             }
         }
     }


### PR DESCRIPTION
This required to handle error messages that were translated through `ApiResponse.translatedError` and also translate them through the new alternative `translateError()`.

At the same time, we took this opportunity to replace the ServerError message that was displayed to the user when receiving a 500 with the generic "an error has occurred" to not give useless info to the user and be iso with iOS.