### PR TITLE
feat: Add runOnMainThread in ThreadUtils.kt

### DIFF
--- a/src/main/kotlin/com/infomaniak/core/utils/ThreadUtils.kt
+++ b/src/main/kotlin/com/infomaniak/core/utils/ThreadUtils.kt
@@ -1,0 +1,31 @@
+/*
+ * Infomaniak Core - Android
+ * Copyright (C) 2025 Infomaniak Network SA
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.infomaniak.core.utils
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.runBlocking
+import splitties.mainthread.isMainThread
+import kotlin.contracts.ExperimentalContracts
+import kotlin.contracts.InvocationKind
+import kotlin.contracts.contract
+
+@OptIn(ExperimentalContracts::class)
+inline fun <R> runOnMainThread(crossinline block: () -> R): R {
+    contract { callsInPlace(block, InvocationKind.EXACTLY_ONCE) }
+    return if (isMainThread) block() else runBlocking(Dispatchers.Main) { block() }
+}


### PR DESCRIPTION
Needed to ensure Realm instances are (unfortunately) instantiated on the single main thread.