### PR TITLE
fix: Fix rare crash that could occur on view recycling

### DIFF
--- a/RecyclerView/src/main/kotlin/com/infomaniak/core/recyclerview/CoroutineScopeViewHolder.kt
+++ b/RecyclerView/src/main/kotlin/com/infomaniak/core/recyclerview/CoroutineScopeViewHolder.kt
@@ -51,6 +51,7 @@ abstract class CoroutineScopeViewHolder<V : View>(
     override fun onBind() = Unit
 
     override fun onUnbind() {
-        currentBindScopeDelegate.invalidate()?.cancel()
+        currentBindScopeDelegate.value?.cancel()
+        currentBindScopeDelegate.reset()
     }
 }

--- a/RecyclerView/src/main/kotlin/com/infomaniak/core/recyclerview/CoroutineScopeViewHolder.kt
+++ b/RecyclerView/src/main/kotlin/com/infomaniak/core/recyclerview/CoroutineScopeViewHolder.kt
@@ -51,7 +51,6 @@ abstract class CoroutineScopeViewHolder<V : View>(
     override fun onBind() = Unit
 
     override fun onUnbind() {
-        currentBindScope.cancel()
-        currentBindScopeDelegate.invalidate()
+        currentBindScopeDelegate.invalidate()?.cancel()
     }
 }

--- a/RecyclerView/src/main/kotlin/com/infomaniak/core/recyclerview/ResettableLazy.kt
+++ b/RecyclerView/src/main/kotlin/com/infomaniak/core/recyclerview/ResettableLazy.kt
@@ -31,8 +31,7 @@ internal class ResettableLazy<T : Any>(private val initializer: () -> T) {
         return value ?: initializer().apply { value = this }
     }
 
-    /**
-     * Returns the value prior to invalidation/removal.
-     */
-    fun invalidate(): T? = value.also { value = null }
+    fun reset() {
+        value = null
+    }
 }

--- a/RecyclerView/src/main/kotlin/com/infomaniak/core/recyclerview/ResettableLazy.kt
+++ b/RecyclerView/src/main/kotlin/com/infomaniak/core/recyclerview/ResettableLazy.kt
@@ -30,7 +30,8 @@ internal class ResettableLazy<T : Any>(private val initializer: () -> T) {
         return value ?: initializer().apply { value = this }
     }
 
-    fun invalidate() {
-        value = null
-    }
+    /**
+     * Returns the value prior to invalidation/removal.
+     */
+    fun invalidate(): T? = value.also { value = null }
 }

--- a/RecyclerView/src/main/kotlin/com/infomaniak/core/recyclerview/ResettableLazy.kt
+++ b/RecyclerView/src/main/kotlin/com/infomaniak/core/recyclerview/ResettableLazy.kt
@@ -21,7 +21,8 @@ import kotlin.reflect.KProperty
 
 internal class ResettableLazy<T : Any>(private val initializer: () -> T) {
 
-    private var value: T? = null
+    var value: T? = null
+        private set
 
     operator fun getValue(
         @Suppress("unused") thisRef: Any?,


### PR DESCRIPTION
The stacktrace of the crash this PR fixes:
```stacktrace
E  FATAL EXCEPTION: main
   Process: com.infomaniak.drive, PID: 19774
java.lang.IllegalStateException: Provide a parentScope in the constructor, or make the Adapter implement LifecycleOwner
	at com.infomaniak.core.recyclerview.CoroutineScopeViewHolder.currentBindScopeDelegate$lambda$0(CoroutineScopeViewHolder.kt:45)
	at com.infomaniak.core.recyclerview.CoroutineScopeViewHolder.$r8$lambda$Brz_99wuy1DcSDOhnTr-z2XXPE8(Unknown Source:0)
	at com.infomaniak.core.recyclerview.CoroutineScopeViewHolder$$ExternalSyntheticLambda0.invoke(D8$$SyntheticClass:0)
	at com.infomaniak.core.recyclerview.ResettableLazy.getValue(ResettableLazy.kt:30)
	at com.infomaniak.core.recyclerview.CoroutineScopeViewHolder.getCurrentBindScope(CoroutineScopeViewHolder.kt:49)
	at com.infomaniak.core.recyclerview.CoroutineScopeViewHolder.onUnbind(CoroutineScopeViewHolder.kt:54)
	at androidx.recyclerview.widget.BindAwareViewHolder.notifyBinding(BindAwareViewHolder.kt:74)
	at androidx.recyclerview.widget.BindAwareViewHolder.resetInternal$RecyclerView_debug(BindAwareViewHolder.kt:69)
	at androidx.recyclerview.widget.BindAwareViewHolder.resetInternal(BindAwareViewHolder.kt:32)
	at androidx.recyclerview.widget.RecyclerView$RecycledViewPool.putRecycledView(RecyclerView.java:6330)
	at androidx.recyclerview.widget.RecyclerView$Recycler.addViewHolderToRecycledViewPool(RecyclerView.java:7181)
	at androidx.recyclerview.widget.RecyclerView$Recycler.recycleViewHolderInternal(RecyclerView.java:7128)
	at androidx.recyclerview.widget.RecyclerView$Recycler.tryGetViewHolderForPositionByDeadline(RecyclerView.java:6808)
	at androidx.recyclerview.widget.RecyclerView$Recycler.getViewForPosition(RecyclerView.java:6757)
	at androidx.recyclerview.widget.RecyclerView$Recycler.getViewForPosition(RecyclerView.java:6753)
	at androidx.recyclerview.widget.LinearLayoutManager$LayoutState.next(LinearLayoutManager.java:2362)
	at androidx.recyclerview.widget.LinearLayoutManager.layoutChunk(LinearLayoutManager.java:1662)
	at androidx.recyclerview.widget.LinearLayoutManager.fill(LinearLayoutManager.java:1622)
	at androidx.recyclerview.widget.LinearLayoutManager.scrollBy(LinearLayoutManager.java:1425)
	at androidx.recyclerview.widget.LinearLayoutManager.scrollVerticallyBy(LinearLayoutManager.java:1158)
	at androidx.recyclerview.widget.RecyclerView.scrollStep(RecyclerView.java:2050)
	at androidx.recyclerview.widget.RecyclerView$ViewFlinger.run(RecyclerView.java:5835)
	at android.view.Choreographer$CallbackRecord.run(Choreographer.java:1406)
	at android.view.Choreographer$CallbackRecord.run(Choreographer.java:1415)
	at android.view.Choreographer.doCallbacks(Choreographer.java:1015)
	at android.view.Choreographer.doFrame(Choreographer.java:941)
	at android.view.Choreographer$FrameDisplayEventReceiver.run(Choreographer.java:1389)
	at android.os.Handler.handleCallback(Handler.java:959)
	at android.os.Handler.dispatchMessage(Handler.java:100)
	at android.os.Looper.loopOnce(Looper.java:232)
	at android.os.Looper.loop(Looper.java:317)
	at android.app.ActivityThread.main(ActivityThread.java:8705)
	at java.lang.reflect.Method.invoke(Native Method)
	at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:580)
	at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:886)
```
