### PR TITLE
chore: Remove versions of Gradle plugins

### DIFF
--- a/AppIntegrity/build.gradle.kts
+++ b/AppIntegrity/build.gradle.kts
@@ -1,7 +1,7 @@
 plugins {
     id("com.android.library")
     alias(core.plugins.kotlin.android)
-    kotlin("plugin.serialization") version core.versions.kotlin
+    kotlin("plugin.serialization")
 }
 
 val coreCompileSdk: Int by rootProject.extra

--- a/MyKSuite/build.gradle.kts
+++ b/MyKSuite/build.gradle.kts
@@ -4,7 +4,7 @@ plugins {
     alias(core.plugins.compose.compiler)
     alias(core.plugins.ksp)
     kotlin("plugin.parcelize")
-    kotlin("plugin.serialization") version core.versions.kotlin
+    kotlin("plugin.serialization")
     id("androidx.navigation.safeargs.kotlin")
 }
 

--- a/WebView/build.gradle.kts
+++ b/WebView/build.gradle.kts
@@ -2,7 +2,7 @@ plugins {
     id("com.android.library")
     alias(core.plugins.kotlin.android)
     alias(core.plugins.compose.compiler)
-    kotlin("plugin.serialization") version core.versions.kotlin
+    kotlin("plugin.serialization")
 }
 
 val coreCompileSdk: Int by rootProject.extra

--- a/gradle/core.versions.toml
+++ b/gradle/core.versions.toml
@@ -9,8 +9,6 @@ coreKtx = "1.6.1"
 integrity = "1.4.0"
 junit = "4.13" # Don't update this because it breaks tests
 junitAndroidx = "1.2.1"
-kotlin = "2.0.21" # Don't bump because of realm-kotlin in mail
-ksp = "2.0.21-1.0.28" # Don't bump because of realm-kotlin in mail
 kotest = "5.9.1"
 kotlinxCoroutines = "1.10.2"
 kotlinxSerializationJson = "1.8.1"
@@ -82,6 +80,6 @@ junit = { group = "junit", name = "junit", version.ref = "junit" }
 robolectric = { module = "org.robolectric:robolectric", version.ref = "robolectric" }
 
 [plugins]
-compose-compiler = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
-kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
-ksp = { id = "com.google.devtools.ksp", version.ref = "ksp" }
+compose-compiler = { id = "org.jetbrains.kotlin.plugin.compose" }
+kotlin-android = { id = "org.jetbrains.kotlin.android" }
+ksp = { id = "com.google.devtools.ksp" }


### PR DESCRIPTION
This will avoid locking project to old dependencies because a project can't update.

Instead, versions can be defined in host projects.