### PR TITLE
fix: Remove too short callTimeout

### DIFF
--- a/Legacy/src/main/java/com/infomaniak/lib/core/auth/CredentialManager.kt
+++ b/Legacy/src/main/java/com/infomaniak/lib/core/auth/CredentialManager.kt
@@ -77,7 +77,8 @@ abstract class CredentialManager {
     private suspend fun getHttpClientUser(userId: Int, timeout: Long?): OkHttpClient {
         return OkHttpClient.Builder().apply {
             timeout?.let {
-                callTimeout(timeout, TimeUnit.SECONDS)
+                // NEVER set `callTimeout` to a too low value, because it would break users on slow connexions.
+                // Think hours or minutes for uploads, and tens of seconds for other calls.
                 readTimeout(timeout, TimeUnit.SECONDS)
                 writeTimeout(timeout, TimeUnit.SECONDS)
                 connectTimeout(timeout, TimeUnit.SECONDS)


### PR DESCRIPTION
This was preventing uploads to succeed on kDrive if the upload bandwidth was smaller than 14Mbps:

((50 * 1024 * 1024 * 8 * 4) / 120) / 1000 = 13,9810133333

Full breakdown
```
(
  (
    50 * 1024 [kio] * 1024 [Mio] * 8 [Mb] *
    4 [parallel chunks]
  ) / 120 [s]
) / 1000 [kbps] / 1000 [Mbps]
```

We're now leaving the default, which is no timeout. Timeout for read, write, and connection, are enough.