### PR TITLE
chore: Extract the rateLimit operator for Flow

### DIFF
--- a/src/main/kotlin/com/infomaniak/core/AtomicCoroutines.kt
+++ b/src/main/kotlin/com/infomaniak/core/AtomicCoroutines.kt
@@ -1,0 +1,47 @@
+/*
+ * Infomaniak Core - Android
+ * Copyright (C) 2025 Infomaniak Network SA
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.infomaniak.core
+
+import kotlinx.coroutines.*
+import kotlinx.coroutines.selects.SelectBuilder
+import kotlinx.coroutines.selects.select
+
+/**
+ * Always return if a select clause from [builder] was selected,
+ * while allowing cancellation, if it happened strictly before one
+ * of these clauses could be selected.
+ */
+suspend inline fun <R> trySelectAtomically(
+    crossinline onCancellation: suspend () -> R,
+    crossinline builder: SelectBuilder<R>.() -> Unit
+): R? = coroutineScope {
+    // We connect `cancellationSignal` to the current job, so it can be used as
+    // a secondary select clause below, even though cancellation is blocked
+    // using `withContext(NonCancellable)`.
+    // The atomic behavior of `select` allows us to get the desired behavior.
+    val cancellationSignal = launch { awaitCancellation() }
+    withContext(NonCancellable) {
+        select {
+            builder() // We need to be biased towards this/these clause(s), so it comes first.
+            cancellationSignal.onJoin { onCancellation() }
+        }.also {
+            // If a builder clause was selected, stop this job to allow coroutineScope to complete.
+            cancellationSignal.cancel()
+        }
+    }
+}

--- a/src/main/kotlin/com/infomaniak/core/SendChannel.kt
+++ b/src/main/kotlin/com/infomaniak/core/SendChannel.kt
@@ -1,0 +1,39 @@
+/*
+ * Infomaniak Core - Android
+ * Copyright (C) 2025 Infomaniak Network SA
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.infomaniak.core
+
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.channels.SendChannel
+import kotlinx.coroutines.currentCoroutineContext
+import kotlinx.coroutines.ensureActive
+
+/**
+ * [SendChannel.send] can throw a [CancellationException] after the value was sent,
+ * which might not be desirable if we want to factor-in whether the value was actually sent.
+ *
+ * That's why this atomic version exists.
+ * It supports cancellation, but if the value is sent, it will return instead, even if it's
+ * happening concurrently to cancellation.
+ *
+ * See [this issue](https://github.com/Kotlin/kotlinx.coroutines/issues/4414) for more details.
+ */
+suspend fun <T> SendChannel<T>.sendAtomic(element: T) {
+    trySelectAtomically<Unit?>(onCancellation = { null }) {
+        onSend(element) {}
+    } ?: currentCoroutineContext().ensureActive()
+}


### PR DESCRIPTION
This commit also exposes its 2 foundations:
`trySelectAtomically`, and `sendAtomic` for `SendChannel<T>`.

This code was [in SwissTransfer](https://github.com/Infomaniak/android-SwissTransfer/blob/e2729a6acb6d2cf4b01a2311b31a0a143410b1a0/app/src/main/java/com/infomaniak/swisstransfer/upload/UploadForegroundService.kt#L208-L265) and will be used in kDrive too, going forward, so it's time to set it up for reuse.