### PR TITLE
feat: InputStream extensions

### DIFF
--- a/Ktor/build.gradle.kts
+++ b/Ktor/build.gradle.kts
@@ -1,0 +1,39 @@
+plugins {
+    id("com.android.library")
+    alias(core.plugins.kotlin.android)
+}
+
+val coreCompileSdk: Int by rootProject.extra
+val coreMinSdk: Int by rootProject.extra
+val javaVersion: JavaVersion by rootProject.extra
+
+android {
+    namespace = "com.infomaniak.core.ktor"
+    compileSdk = coreCompileSdk
+
+    defaultConfig {
+        minSdk = coreMinSdk
+
+        testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
+        consumerProguardFiles("consumer-rules.pro")
+    }
+
+    buildTypes {
+        release {
+            isMinifyEnabled = false
+            proguardFiles(getDefaultProguardFile("proguard-android-optimize.txt"), "proguard-rules.pro")
+        }
+    }
+    compileOptions {
+        sourceCompatibility = javaVersion
+        targetCompatibility = javaVersion
+    }
+    kotlinOptions {
+        jvmTarget = javaVersion.toString()
+    }
+}
+
+dependencies {
+    api(core.ktor.client.core)
+    implementation(core.kotlinx.coroutines.core)
+}

--- a/Ktor/proguard-rules.pro
+++ b/Ktor/proguard-rules.pro
@@ -1,0 +1,21 @@
+# Add project specific ProGuard rules here.
+# You can control the set of applied configuration files using the
+# proguardFiles setting in build.gradle.
+#
+# For more details, see
+#   http://developer.android.com/guide/developing/tools/proguard.html
+
+# If your project uses WebView with JS, uncomment the following
+# and specify the fully qualified class name to the JavaScript interface
+# class:
+#-keepclassmembers class fqcn.of.javascript.interface.for.webview {
+#   public *;
+#}
+
+# Uncomment this to preserve the line number information for
+# debugging stack traces.
+#-keepattributes SourceFile,LineNumberTable
+
+# If you keep the line number information, uncomment this to
+# hide the original source file name.
+#-renamesourcefileattribute SourceFile

--- a/Ktor/src/main/kotlin/com/infomaniak/core/ktor/InputStreamToOutgoingContent.kt
+++ b/Ktor/src/main/kotlin/com/infomaniak/core/ktor/InputStreamToOutgoingContent.kt
@@ -1,0 +1,81 @@
+/*
+ * Infomaniak Core - Android
+ * Copyright (C) 2025 Infomaniak Network SA
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.infomaniak.core.ktor
+
+import io.ktor.http.content.*
+import io.ktor.utils.io.*
+import io.ktor.utils.io.jvm.javaio.*
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ensureActive
+import kotlinx.coroutines.invoke
+import java.io.EOFException
+import java.io.IOException
+import java.io.InputStream
+import java.io.OutputStream
+import kotlin.coroutines.CoroutineContext
+import kotlin.coroutines.EmptyCoroutineContext
+
+fun InputStream.toOutgoingContent(
+    length: Long
+): OutgoingContent.WriteChannelContent = object : OutgoingContent.WriteChannelContent() {
+    override val contentLength = length
+
+    override suspend fun writeTo(channel: ByteWriteChannel) = Dispatchers.IO {
+        use { inputStream ->
+            inputStream.copyToUntil(channel.toOutputStream(), count = length, coroutineContext = coroutineContext)
+        }
+    }
+}
+
+/**
+ * Copies [count] bytes of this [InputStream] to [out].
+ *
+ * **Note** It is the caller's responsibility to close both of these resources.
+ *
+ * The implementation is based on the [java.io.InputStream.copyTo] extension from kotlin.io,
+ * but also handles cancellation if the [coroutineContext] is passed,
+ * in addition to copying only the passed number of bytes in [count].
+ */
+@Throws(IOException::class)
+private fun InputStream.copyToUntil(
+    out: OutputStream,
+    bufferSize: Int = DEFAULT_BUFFER_SIZE,
+    count: Long,
+    coroutineContext: CoroutineContext = EmptyCoroutineContext
+) {
+    var bytesRemaining: Long = count
+    val buffer = ByteArray(bufferSize)
+    do {
+        coroutineContext.ensureActive()
+        val bytesToCopy = minOf(bytesRemaining, bufferSize.toLong()).toInt()
+        val readBytesCount = read(/* b = */ buffer, /* off = */ 0, /* len = */ bytesToCopy)
+
+        if (readBytesCount == 0) {
+            throw IOException("Wanted to read $bytesToCopy bytes but got zero. $bytesRemaining/$count bytes couldn't be copied.")
+        }
+        if (readBytesCount < 0) throw EOFException("$bytesRemaining/$count bytes couldn't be copied.")
+
+        coroutineContext.ensureActive()
+        out.write(
+            /* b = */ buffer,
+            /* off = */ 0,
+            /* len = */ readBytesCount
+        )
+        bytesRemaining -= readBytesCount
+    } while (bytesRemaining > 0)
+}

--- a/src/main/kotlin/com/infomaniak/core/io/InputStream.kt
+++ b/src/main/kotlin/com/infomaniak/core/io/InputStream.kt
@@ -1,0 +1,56 @@
+/*
+ * Infomaniak Core - Android
+ * Copyright (C) 2025 Infomaniak Network SA
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.infomaniak.core.io
+
+import kotlinx.coroutines.ensureActive
+import java.io.EOFException
+import java.io.IOException
+import java.io.InputStream
+import kotlin.coroutines.CoroutineContext
+import kotlin.coroutines.EmptyCoroutineContext
+
+/**
+ * **DISCLAIMER: Code copied from the JDK, might not follow all our coding conventions.**
+ *
+ * The implementation is copied from [InputStream.skipNBytes] that is only available starting API 34,
+ * but also supports cancellation if the [coroutineContext] is passed.
+ */
+@Throws(IOException::class)
+fun InputStream.skipExactly(
+    numberOfBytes: Long,
+    coroutineContext: CoroutineContext = EmptyCoroutineContext
+) {
+    var n = numberOfBytes
+    while (n > 0) {
+        coroutineContext.ensureActive()
+        val ns: Long = skip(n)
+        if (ns > 0 && ns <= n) {
+            // adjust number to skip
+            n -= ns
+        } else if (ns == 0L) { // no bytes skipped
+            // read one byte to check for EOS
+            if (read() == -1) {
+                throw EOFException()
+            }
+            // one byte read so decrement number to skip
+            n--
+        } else { // skipped negative or too many bytes
+            throw IOException("Unable to skip exactly")
+        }
+    }
+}


### PR DESCRIPTION
`skipExactly` was copied from [SwissTransfer here](https://github.com/Infomaniak/android-SwissTransfer/blob/e2729a6acb6d2cf4b01a2311b31a0a143410b1a0/app/src/main/java/com/infomaniak/swisstransfer/upload/UriToOutgoingContent.kt#L52-L81), and `Inpustream.toOutgoingContent` was inspired by `Uri.toOutgoingContent` from [SwissTransfer here](https://github.com/Infomaniak/android-SwissTransfer/blob/e2729a6acb6d2cf4b01a2311b31a0a143410b1a0/app/src/main/java/com/infomaniak/swisstransfer/upload/UriToOutgoingContent.kt#L35-L50).