### PR TITLE
feat: Use new valid email detection regex that matches closer to RFC5321

### DIFF
--- a/src/main/kotlin/com/infomaniak/core/utils/EmailUtils.kt
+++ b/src/main/kotlin/com/infomaniak/core/utils/EmailUtils.kt
@@ -1,6 +1,6 @@
 /*
  * Infomaniak Core - Android
- * Copyright (C) 2024 Infomaniak Network SA
+ * Copyright (C) 2024-2025 Infomaniak Network SA
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -17,6 +17,14 @@
  */
 package com.infomaniak.core.utils
 
-import android.util.Patterns
 
-fun String.isValidEmail(): Boolean = Patterns.EMAIL_ADDRESS.matcher(trim()).matches()
+/**
+ * This regex should be closer to RFC5321 compared to Patterns.EMAIL_ADDRESS which is missing, amongst many things, the
+ * characters #&~!^`{}/=$*?|
+ *
+ * This regex comes from the iOS mail app that supports more email addresses than Android did with Patterns.EMAIL_ADDRESS
+ */
+private val validEmailPattern =
+    "(?:[a-z0-9!#$%&'*+/=?^_`{|}~-]+(?:\\.[a-z0-9!#$%&'*+/=?^_`{|}~-]+)*|\"(?:[\\x01-\\x08\\x0b\\x0c\\x0e-\\x1f\\x21\\x23-\\x5b\\x5d-\\x7f]|\\\\[\\x01-\\x09\\x0b\\x0c\\x0e-\\x7f])*\")@(?:(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\\.)+[a-z0-9](?:[a-z0-9-]*[a-z0-9])?|\\[(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?|[a-z0-9-]*[a-z0-9]:(?:[\\x01-\\x08\\x0b\\x0c\\x0e-\\x1f\\x21-\\x5a\\x53-\\x7f]|\\\\[\\x01-\\x09\\x0b\\x0c\\x0e-\\x7f])+)\\])".toRegex()
+
+fun String.isValidEmail(): Boolean = validEmailPattern.matches(this)

--- a/src/main/kotlin/com/infomaniak/core/utils/EmailUtils.kt
+++ b/src/main/kotlin/com/infomaniak/core/utils/EmailUtils.kt
@@ -17,6 +17,9 @@
  */
 package com.infomaniak.core.utils
 
+import android.util.Patterns
+
+fun String.isValidEmail(): Boolean = Patterns.EMAIL_ADDRESS.matcher(trim()).matches()
 
 /**
  * This regex should be closer to RFC5321 compared to Patterns.EMAIL_ADDRESS which is missing, amongst many things, the
@@ -24,7 +27,13 @@ package com.infomaniak.core.utils
  *
  * This regex comes from the iOS mail app that supports more email addresses than Android did with Patterns.EMAIL_ADDRESS
  */
-private val validEmailPattern =
+private val rfc5321ValidEmailPattern =
     "(?:[a-z0-9!#$%&'*+/=?^_`{|}~-]+(?:\\.[a-z0-9!#$%&'*+/=?^_`{|}~-]+)*|\"(?:[\\x01-\\x08\\x0b\\x0c\\x0e-\\x1f\\x21\\x23-\\x5b\\x5d-\\x7f]|\\\\[\\x01-\\x09\\x0b\\x0c\\x0e-\\x7f])*\")@(?:(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\\.)+[a-z0-9](?:[a-z0-9-]*[a-z0-9])?|\\[(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?|[a-z0-9-]*[a-z0-9]:(?:[\\x01-\\x08\\x0b\\x0c\\x0e-\\x1f\\x21-\\x5a\\x53-\\x7f]|\\\\[\\x01-\\x09\\x0b\\x0c\\x0e-\\x7f])+)\\])".toRegex()
 
-fun String.isValidEmail(): Boolean = validEmailPattern.matches(this)
+/**
+ * Detects more email addresses as valid compared to [isValidEmail] which is based on [Patterns.EMAIL_ADDRESS] which doesn't adapt
+ * all of RFC5321.
+ *
+ * @see rfc5321ValidEmailPattern
+ */
+fun String.isEmailRfc5321Compliant(): Boolean = rfc5321ValidEmailPattern.matches(this)


### PR DESCRIPTION
The regex comes from what iOS was using in mail. Thanks to this update, we support more valid email adresses and we are more iso.

To get a truly generic method that can be used for the mail app I had to remove the trim() part of the logic, but it was only used in the SwissTransfer app and can be fixed there instead