### PR TITLE
feat: Automatically define a jetpack compose MaterialTheme based on the theme defined in xml

### DIFF
--- a/Compose/MaterialThemeFromXml/build.gradle.kts
+++ b/Compose/MaterialThemeFromXml/build.gradle.kts
@@ -1,0 +1,60 @@
+/*
+ * Infomaniak Core - Android
+ * Copyright (C) 2025 Infomaniak Network SA
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+plugins {
+    id("com.android.library")
+    alias(core.plugins.kotlin.android)
+    alias(core.plugins.compose.compiler)
+}
+
+val coreCompileSdk: Int by rootProject.extra
+val coreMinSdk: Int by rootProject.extra
+val javaVersion: JavaVersion by rootProject.extra
+
+android {
+    namespace = "com.infomaniak.core.compose.materialthemefromxml"
+    compileSdk = coreCompileSdk
+
+    defaultConfig {
+        minSdk = coreMinSdk
+    }
+
+    compileOptions {
+        sourceCompatibility = javaVersion
+        targetCompatibility = javaVersion
+    }
+
+    buildFeatures {
+        compose = true
+    }
+
+    composeOptions {
+        kotlinCompilerExtensionVersion = "1.5.14"
+    }
+
+    kotlinOptions {
+        jvmTarget = javaVersion.toString()
+    }
+}
+
+dependencies {
+    implementation(core.material)
+
+    implementation(platform(core.compose.bom))
+    implementation(core.compose.runtime)
+    implementation(core.compose.material3)
+}

--- a/Compose/MaterialThemeFromXml/src/main/kotlin/com/infomaniak/core/compose/materialthemefromxml/MaterialThemeFromXml.kt
+++ b/Compose/MaterialThemeFromXml/src/main/kotlin/com/infomaniak/core/compose/materialthemefromxml/MaterialThemeFromXml.kt
@@ -28,8 +28,8 @@ import com.google.android.material.color.MaterialColors
 import com.google.android.material.R as RMaterial
 
 /**
- * Automatically defines the jetpack compose MaterialTheme based on the values defined as an XML theme in the context where
- * this is called.
+ * Automatically defines the Jetpack Compose MaterialTheme based on the
+ * values defined as an XML theme in the context where this is called.
  */
 @Composable
 fun MaterialThemeFromXml(content: @Composable () -> Unit): Unit = with(LocalContext.current) {
@@ -56,8 +56,8 @@ fun MaterialThemeFromXml(content: @Composable () -> Unit): Unit = with(LocalCont
             onSurface = getMaterialColor(RMaterial.attr.colorOnSurface),
             surfaceVariant = getMaterialColor(RMaterial.attr.colorSurfaceVariant),
             onSurfaceVariant = getMaterialColor(RMaterial.attr.colorOnSurfaceVariant),
-            // surfaceTint doesn't exist in xml theming, in jetpack compose it automatically gets defaulted to `primary` when you
-            // try to override a theme using darkColorScheme or lightColorScheme
+            // `surfaceTint` doesn't exist in XML theming, in Jetpack Compose it automatically gets defaulted
+            // to `primary` when you try to override a theme using darkColorScheme or lightColorScheme
             surfaceTint = primary,
             inverseSurface = getMaterialColor(RMaterial.attr.colorSurfaceInverse),
             inverseOnSurface = getMaterialColor(RMaterial.attr.colorOnSurfaceInverse),

--- a/Compose/MaterialThemeFromXml/src/main/kotlin/com/infomaniak/core/compose/materialthemefromxml/MaterialThemeFromXml.kt
+++ b/Compose/MaterialThemeFromXml/src/main/kotlin/com/infomaniak/core/compose/materialthemefromxml/MaterialThemeFromXml.kt
@@ -1,0 +1,124 @@
+/*
+ * Infomaniak Core - Android
+ * Copyright (C) 2025 Infomaniak Network SA
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.infomaniak.core.compose.materialthemefromxml
+
+import android.content.Context
+import androidx.annotation.AttrRes
+import androidx.compose.foundation.isSystemInDarkTheme
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.darkColorScheme
+import androidx.compose.material3.lightColorScheme
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
+import com.google.android.material.color.MaterialColors
+import com.google.android.material.R as RMaterial
+
+/**
+ * Automatically defines the jetpack compose MaterialTheme based on the values defined as an XML theme in the context where
+ * this is called.
+ */
+@Composable
+fun MaterialThemeFromXml(content: @Composable () -> Unit) {
+    val context = LocalContext.current
+
+    MaterialTheme(
+        colorScheme = if (isSystemInDarkTheme()) {
+            darkColorScheme(
+                primary = getMaterialColor(context, RMaterial.attr.colorPrimary),
+                onPrimary = getMaterialColor(context, RMaterial.attr.colorOnPrimary),
+                primaryContainer = getMaterialColor(context, RMaterial.attr.colorPrimaryContainer),
+                onPrimaryContainer = getMaterialColor(context, RMaterial.attr.colorOnPrimaryContainer),
+                inversePrimary = getMaterialColor(context, RMaterial.attr.colorPrimaryInverse),
+                secondary = getMaterialColor(context, RMaterial.attr.colorSecondary),
+                onSecondary = getMaterialColor(context, RMaterial.attr.colorOnSecondary),
+                secondaryContainer = getMaterialColor(context, RMaterial.attr.colorSecondaryContainer),
+                onSecondaryContainer = getMaterialColor(context, RMaterial.attr.colorOnSecondaryContainer),
+                tertiary = getMaterialColor(context, RMaterial.attr.colorTertiary),
+                onTertiary = getMaterialColor(context, RMaterial.attr.colorOnTertiary),
+                tertiaryContainer = getMaterialColor(context, RMaterial.attr.colorTertiaryContainer),
+                onTertiaryContainer = getMaterialColor(context, RMaterial.attr.colorOnTertiaryContainer),
+                background = getMaterialColor(context, RMaterial.attr.background),
+                onBackground = getMaterialColor(context, RMaterial.attr.colorOnBackground),
+                surface = getMaterialColor(context, RMaterial.attr.colorSurface),
+                onSurface = getMaterialColor(context, RMaterial.attr.colorOnSurface),
+                surfaceVariant = getMaterialColor(context, RMaterial.attr.colorSurfaceVariant),
+                onSurfaceVariant = getMaterialColor(context, RMaterial.attr.colorOnSurfaceVariant),
+                // surfaceTint doesn't exist in xml theming, in jetpack compose it automatically gets defaulted to `primary`
+                inverseSurface = getMaterialColor(context, RMaterial.attr.colorSurfaceInverse),
+                inverseOnSurface = getMaterialColor(context, RMaterial.attr.colorOnSurfaceInverse),
+                error = getMaterialColor(context, RMaterial.attr.colorError),
+                onError = getMaterialColor(context, RMaterial.attr.colorOnError),
+                errorContainer = getMaterialColor(context, RMaterial.attr.colorErrorContainer),
+                onErrorContainer = getMaterialColor(context, RMaterial.attr.colorOnErrorContainer),
+                outline = getMaterialColor(context, RMaterial.attr.colorOutline),
+                outlineVariant = getMaterialColor(context, RMaterial.attr.colorOutlineVariant),
+                scrim = getMaterialColor(context, RMaterial.attr.scrimBackground),
+                surfaceBright = getMaterialColor(context, RMaterial.attr.colorSurfaceBright),
+                surfaceContainer = getMaterialColor(context, RMaterial.attr.colorSurfaceContainer),
+                surfaceContainerHigh = getMaterialColor(context, RMaterial.attr.colorSurfaceContainerHigh),
+                surfaceContainerHighest = getMaterialColor(context, RMaterial.attr.colorSurfaceContainerHighest),
+                surfaceContainerLow = getMaterialColor(context, RMaterial.attr.colorSurfaceContainerLow),
+                surfaceContainerLowest = getMaterialColor(context, RMaterial.attr.colorSurfaceContainerLowest),
+                surfaceDim = getMaterialColor(context, RMaterial.attr.colorSurfaceDim),
+            )
+        } else {
+            lightColorScheme(
+                primary = getMaterialColor(context, RMaterial.attr.colorPrimary),
+                onPrimary = getMaterialColor(context, RMaterial.attr.colorOnPrimary),
+                primaryContainer = getMaterialColor(context, RMaterial.attr.colorPrimaryContainer),
+                onPrimaryContainer = getMaterialColor(context, RMaterial.attr.colorOnPrimaryContainer),
+                inversePrimary = getMaterialColor(context, RMaterial.attr.colorPrimaryInverse),
+                secondary = getMaterialColor(context, RMaterial.attr.colorSecondary),
+                onSecondary = getMaterialColor(context, RMaterial.attr.colorOnSecondary),
+                secondaryContainer = getMaterialColor(context, RMaterial.attr.colorSecondaryContainer),
+                onSecondaryContainer = getMaterialColor(context, RMaterial.attr.colorOnSecondaryContainer),
+                tertiary = getMaterialColor(context, RMaterial.attr.colorTertiary),
+                onTertiary = getMaterialColor(context, RMaterial.attr.colorOnTertiary),
+                tertiaryContainer = getMaterialColor(context, RMaterial.attr.colorTertiaryContainer),
+                onTertiaryContainer = getMaterialColor(context, RMaterial.attr.colorOnTertiaryContainer),
+                background = getMaterialColor(context, RMaterial.attr.background),
+                onBackground = getMaterialColor(context, RMaterial.attr.colorOnBackground),
+                surface = getMaterialColor(context, RMaterial.attr.colorSurface),
+                onSurface = getMaterialColor(context, RMaterial.attr.colorOnSurface),
+                surfaceVariant = getMaterialColor(context, RMaterial.attr.colorSurfaceVariant),
+                onSurfaceVariant = getMaterialColor(context, RMaterial.attr.colorOnSurfaceVariant),
+                // surfaceTint doesn't exist in xml theming, in jetpack compose it automatically gets defaulted to `primary`
+                inverseSurface = getMaterialColor(context, RMaterial.attr.colorSurfaceInverse),
+                inverseOnSurface = getMaterialColor(context, RMaterial.attr.colorOnSurfaceInverse),
+                error = getMaterialColor(context, RMaterial.attr.colorError),
+                onError = getMaterialColor(context, RMaterial.attr.colorOnError),
+                errorContainer = getMaterialColor(context, RMaterial.attr.colorErrorContainer),
+                onErrorContainer = getMaterialColor(context, RMaterial.attr.colorOnErrorContainer),
+                outline = getMaterialColor(context, RMaterial.attr.colorOutline),
+                outlineVariant = getMaterialColor(context, RMaterial.attr.colorOutlineVariant),
+                scrim = getMaterialColor(context, RMaterial.attr.scrimBackground),
+                surfaceBright = getMaterialColor(context, RMaterial.attr.colorSurfaceBright),
+                surfaceContainer = getMaterialColor(context, RMaterial.attr.colorSurfaceContainer),
+                surfaceContainerHigh = getMaterialColor(context, RMaterial.attr.colorSurfaceContainerHigh),
+                surfaceContainerHighest = getMaterialColor(context, RMaterial.attr.colorSurfaceContainerHighest),
+                surfaceContainerLow = getMaterialColor(context, RMaterial.attr.colorSurfaceContainerLow),
+                surfaceContainerLowest = getMaterialColor(context, RMaterial.attr.colorSurfaceContainerLowest),
+                surfaceDim = getMaterialColor(context, RMaterial.attr.colorSurfaceDim),
+            )
+        },
+        content = content,
+    )
+}
+
+private fun getMaterialColor(context: Context, @AttrRes colorId: Int) = Color(MaterialColors.getColor(context, colorId, 0))

--- a/Compose/MaterialThemeFromXml/src/main/kotlin/com/infomaniak/core/compose/materialthemefromxml/MaterialThemeFromXml.kt
+++ b/Compose/MaterialThemeFromXml/src/main/kotlin/com/infomaniak/core/compose/materialthemefromxml/MaterialThemeFromXml.kt
@@ -19,10 +19,8 @@ package com.infomaniak.core.compose.materialthemefromxml
 
 import android.content.Context
 import androidx.annotation.AttrRes
-import androidx.compose.foundation.isSystemInDarkTheme
+import androidx.compose.material3.ColorScheme
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.darkColorScheme
-import androidx.compose.material3.lightColorScheme
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
@@ -34,91 +32,52 @@ import com.google.android.material.R as RMaterial
  * this is called.
  */
 @Composable
-fun MaterialThemeFromXml(content: @Composable () -> Unit) {
-    val context = LocalContext.current
+fun MaterialThemeFromXml(content: @Composable () -> Unit): Unit = with(LocalContext.current) {
+    val primary = getMaterialColor(RMaterial.attr.colorPrimary)
 
     MaterialTheme(
-        colorScheme = if (isSystemInDarkTheme()) {
-            darkColorScheme(
-                primary = getMaterialColor(context, RMaterial.attr.colorPrimary),
-                onPrimary = getMaterialColor(context, RMaterial.attr.colorOnPrimary),
-                primaryContainer = getMaterialColor(context, RMaterial.attr.colorPrimaryContainer),
-                onPrimaryContainer = getMaterialColor(context, RMaterial.attr.colorOnPrimaryContainer),
-                inversePrimary = getMaterialColor(context, RMaterial.attr.colorPrimaryInverse),
-                secondary = getMaterialColor(context, RMaterial.attr.colorSecondary),
-                onSecondary = getMaterialColor(context, RMaterial.attr.colorOnSecondary),
-                secondaryContainer = getMaterialColor(context, RMaterial.attr.colorSecondaryContainer),
-                onSecondaryContainer = getMaterialColor(context, RMaterial.attr.colorOnSecondaryContainer),
-                tertiary = getMaterialColor(context, RMaterial.attr.colorTertiary),
-                onTertiary = getMaterialColor(context, RMaterial.attr.colorOnTertiary),
-                tertiaryContainer = getMaterialColor(context, RMaterial.attr.colorTertiaryContainer),
-                onTertiaryContainer = getMaterialColor(context, RMaterial.attr.colorOnTertiaryContainer),
-                background = getMaterialColor(context, RMaterial.attr.background),
-                onBackground = getMaterialColor(context, RMaterial.attr.colorOnBackground),
-                surface = getMaterialColor(context, RMaterial.attr.colorSurface),
-                onSurface = getMaterialColor(context, RMaterial.attr.colorOnSurface),
-                surfaceVariant = getMaterialColor(context, RMaterial.attr.colorSurfaceVariant),
-                onSurfaceVariant = getMaterialColor(context, RMaterial.attr.colorOnSurfaceVariant),
-                // surfaceTint doesn't exist in xml theming, in jetpack compose it automatically gets defaulted to `primary`
-                inverseSurface = getMaterialColor(context, RMaterial.attr.colorSurfaceInverse),
-                inverseOnSurface = getMaterialColor(context, RMaterial.attr.colorOnSurfaceInverse),
-                error = getMaterialColor(context, RMaterial.attr.colorError),
-                onError = getMaterialColor(context, RMaterial.attr.colorOnError),
-                errorContainer = getMaterialColor(context, RMaterial.attr.colorErrorContainer),
-                onErrorContainer = getMaterialColor(context, RMaterial.attr.colorOnErrorContainer),
-                outline = getMaterialColor(context, RMaterial.attr.colorOutline),
-                outlineVariant = getMaterialColor(context, RMaterial.attr.colorOutlineVariant),
-                scrim = getMaterialColor(context, RMaterial.attr.scrimBackground),
-                surfaceBright = getMaterialColor(context, RMaterial.attr.colorSurfaceBright),
-                surfaceContainer = getMaterialColor(context, RMaterial.attr.colorSurfaceContainer),
-                surfaceContainerHigh = getMaterialColor(context, RMaterial.attr.colorSurfaceContainerHigh),
-                surfaceContainerHighest = getMaterialColor(context, RMaterial.attr.colorSurfaceContainerHighest),
-                surfaceContainerLow = getMaterialColor(context, RMaterial.attr.colorSurfaceContainerLow),
-                surfaceContainerLowest = getMaterialColor(context, RMaterial.attr.colorSurfaceContainerLowest),
-                surfaceDim = getMaterialColor(context, RMaterial.attr.colorSurfaceDim),
-            )
-        } else {
-            lightColorScheme(
-                primary = getMaterialColor(context, RMaterial.attr.colorPrimary),
-                onPrimary = getMaterialColor(context, RMaterial.attr.colorOnPrimary),
-                primaryContainer = getMaterialColor(context, RMaterial.attr.colorPrimaryContainer),
-                onPrimaryContainer = getMaterialColor(context, RMaterial.attr.colorOnPrimaryContainer),
-                inversePrimary = getMaterialColor(context, RMaterial.attr.colorPrimaryInverse),
-                secondary = getMaterialColor(context, RMaterial.attr.colorSecondary),
-                onSecondary = getMaterialColor(context, RMaterial.attr.colorOnSecondary),
-                secondaryContainer = getMaterialColor(context, RMaterial.attr.colorSecondaryContainer),
-                onSecondaryContainer = getMaterialColor(context, RMaterial.attr.colorOnSecondaryContainer),
-                tertiary = getMaterialColor(context, RMaterial.attr.colorTertiary),
-                onTertiary = getMaterialColor(context, RMaterial.attr.colorOnTertiary),
-                tertiaryContainer = getMaterialColor(context, RMaterial.attr.colorTertiaryContainer),
-                onTertiaryContainer = getMaterialColor(context, RMaterial.attr.colorOnTertiaryContainer),
-                background = getMaterialColor(context, RMaterial.attr.background),
-                onBackground = getMaterialColor(context, RMaterial.attr.colorOnBackground),
-                surface = getMaterialColor(context, RMaterial.attr.colorSurface),
-                onSurface = getMaterialColor(context, RMaterial.attr.colorOnSurface),
-                surfaceVariant = getMaterialColor(context, RMaterial.attr.colorSurfaceVariant),
-                onSurfaceVariant = getMaterialColor(context, RMaterial.attr.colorOnSurfaceVariant),
-                // surfaceTint doesn't exist in xml theming, in jetpack compose it automatically gets defaulted to `primary`
-                inverseSurface = getMaterialColor(context, RMaterial.attr.colorSurfaceInverse),
-                inverseOnSurface = getMaterialColor(context, RMaterial.attr.colorOnSurfaceInverse),
-                error = getMaterialColor(context, RMaterial.attr.colorError),
-                onError = getMaterialColor(context, RMaterial.attr.colorOnError),
-                errorContainer = getMaterialColor(context, RMaterial.attr.colorErrorContainer),
-                onErrorContainer = getMaterialColor(context, RMaterial.attr.colorOnErrorContainer),
-                outline = getMaterialColor(context, RMaterial.attr.colorOutline),
-                outlineVariant = getMaterialColor(context, RMaterial.attr.colorOutlineVariant),
-                scrim = getMaterialColor(context, RMaterial.attr.scrimBackground),
-                surfaceBright = getMaterialColor(context, RMaterial.attr.colorSurfaceBright),
-                surfaceContainer = getMaterialColor(context, RMaterial.attr.colorSurfaceContainer),
-                surfaceContainerHigh = getMaterialColor(context, RMaterial.attr.colorSurfaceContainerHigh),
-                surfaceContainerHighest = getMaterialColor(context, RMaterial.attr.colorSurfaceContainerHighest),
-                surfaceContainerLow = getMaterialColor(context, RMaterial.attr.colorSurfaceContainerLow),
-                surfaceContainerLowest = getMaterialColor(context, RMaterial.attr.colorSurfaceContainerLowest),
-                surfaceDim = getMaterialColor(context, RMaterial.attr.colorSurfaceDim),
-            )
-        },
+        colorScheme = ColorScheme(
+            primary = primary,
+            onPrimary = getMaterialColor(RMaterial.attr.colorOnPrimary),
+            primaryContainer = getMaterialColor(RMaterial.attr.colorPrimaryContainer),
+            onPrimaryContainer = getMaterialColor(RMaterial.attr.colorOnPrimaryContainer),
+            inversePrimary = getMaterialColor(RMaterial.attr.colorPrimaryInverse),
+            secondary = getMaterialColor(RMaterial.attr.colorSecondary),
+            onSecondary = getMaterialColor(RMaterial.attr.colorOnSecondary),
+            secondaryContainer = getMaterialColor(RMaterial.attr.colorSecondaryContainer),
+            onSecondaryContainer = getMaterialColor(RMaterial.attr.colorOnSecondaryContainer),
+            tertiary = getMaterialColor(RMaterial.attr.colorTertiary),
+            onTertiary = getMaterialColor(RMaterial.attr.colorOnTertiary),
+            tertiaryContainer = getMaterialColor(RMaterial.attr.colorTertiaryContainer),
+            onTertiaryContainer = getMaterialColor(RMaterial.attr.colorOnTertiaryContainer),
+            background = getMaterialColor(RMaterial.attr.background),
+            onBackground = getMaterialColor(RMaterial.attr.colorOnBackground),
+            surface = getMaterialColor(RMaterial.attr.colorSurface),
+            onSurface = getMaterialColor(RMaterial.attr.colorOnSurface),
+            surfaceVariant = getMaterialColor(RMaterial.attr.colorSurfaceVariant),
+            onSurfaceVariant = getMaterialColor(RMaterial.attr.colorOnSurfaceVariant),
+            // surfaceTint doesn't exist in xml theming, in jetpack compose it automatically gets defaulted to `primary` when you
+            // try to override a theme using darkColorScheme or lightColorScheme
+            surfaceTint = primary,
+            inverseSurface = getMaterialColor(RMaterial.attr.colorSurfaceInverse),
+            inverseOnSurface = getMaterialColor(RMaterial.attr.colorOnSurfaceInverse),
+            error = getMaterialColor(RMaterial.attr.colorError),
+            onError = getMaterialColor(RMaterial.attr.colorOnError),
+            errorContainer = getMaterialColor(RMaterial.attr.colorErrorContainer),
+            onErrorContainer = getMaterialColor(RMaterial.attr.colorOnErrorContainer),
+            outline = getMaterialColor(RMaterial.attr.colorOutline),
+            outlineVariant = getMaterialColor(RMaterial.attr.colorOutlineVariant),
+            scrim = getMaterialColor(RMaterial.attr.scrimBackground),
+            surfaceBright = getMaterialColor(RMaterial.attr.colorSurfaceBright),
+            surfaceContainer = getMaterialColor(RMaterial.attr.colorSurfaceContainer),
+            surfaceContainerHigh = getMaterialColor(RMaterial.attr.colorSurfaceContainerHigh),
+            surfaceContainerHighest = getMaterialColor(RMaterial.attr.colorSurfaceContainerHighest),
+            surfaceContainerLow = getMaterialColor(RMaterial.attr.colorSurfaceContainerLow),
+            surfaceContainerLowest = getMaterialColor(RMaterial.attr.colorSurfaceContainerLowest),
+            surfaceDim = getMaterialColor(RMaterial.attr.colorSurfaceDim),
+        ),
         content = content,
     )
 }
 
-private fun getMaterialColor(context: Context, @AttrRes colorId: Int) = Color(MaterialColors.getColor(context, colorId, 0))
+private fun Context.getMaterialColor(@AttrRes colorId: Int) = Color(MaterialColors.getColor(this, colorId, 0))


### PR DESCRIPTION
We often need to use jetpack compose code inside of projects defined in xml and the material theme is only defined at the xml level in these projects. This PR adds a module that defines a composable method that will automatically take all xml defined material colors and set them inside a jetpack compose MaterialTheme. This way we can easily code jetpack compose UI that adapt to each app's theme