### PR TITLE
feat(CrossAppLogin): Add CrossAppLogin façade + IPC server impl

### DIFF
--- a/CrossAppLogin/build.gradle.kts
+++ b/CrossAppLogin/build.gradle.kts
@@ -1,0 +1,48 @@
+plugins {
+    id("com.android.library")
+    alias(core.plugins.kotlin.android)
+}
+
+val coreCompileSdk: Int by rootProject.extra
+val coreMinSdk: Int by rootProject.extra
+val javaVersion: JavaVersion by rootProject.extra
+
+android {
+    namespace = "com.infomaniak.core.login.crossapp"
+    compileSdk = coreCompileSdk
+
+    defaultConfig {
+        minSdk = coreMinSdk
+
+        testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
+        consumerProguardFiles("consumer-rules.pro")
+    }
+
+    buildTypes {
+        release {
+            isMinifyEnabled = false
+            proguardFiles(getDefaultProguardFile("proguard-android-optimize.txt"), "proguard-rules.pro")
+        }
+    }
+
+    compileOptions {
+        sourceCompatibility = javaVersion
+        targetCompatibility = javaVersion
+    }
+
+    kotlinOptions {
+        jvmTarget = javaVersion.toString()
+    }
+}
+
+dependencies {
+    api(core.kotlinx.coroutines.core)
+    api(core.androidx.lifecycle.runtime.ktx)
+    api(core.androidx.lifecycle.service)
+    api(core.kotlinx.serialization.protobuf)
+
+    implementation(core.splitties.mainthread)
+
+    testImplementation(core.junit)
+    androidTestImplementation(core.androidx.junit)
+}

--- a/CrossAppLogin/build.gradle.kts
+++ b/CrossAppLogin/build.gradle.kts
@@ -41,6 +41,7 @@ dependencies {
     api(core.androidx.lifecycle.service)
     api(core.kotlinx.serialization.protobuf)
 
+    implementation(project(":Core"))
     implementation(core.splitties.mainthread)
 
     testImplementation(core.junit)

--- a/CrossAppLogin/build.gradle.kts
+++ b/CrossAppLogin/build.gradle.kts
@@ -42,6 +42,7 @@ dependencies {
     api(core.kotlinx.serialization.protobuf)
 
     implementation(project(":Core"))
+    implementation(project(":Core:Legacy"))
     implementation(core.splitties.mainthread)
 
     testImplementation(core.junit)

--- a/CrossAppLogin/proguard-rules.pro
+++ b/CrossAppLogin/proguard-rules.pro
@@ -1,0 +1,21 @@
+# Add project specific ProGuard rules here.
+# You can control the set of applied configuration files using the
+# proguardFiles setting in build.gradle.
+#
+# For more details, see
+#   http://developer.android.com/guide/developing/tools/proguard.html
+
+# If your project uses WebView with JS, uncomment the following
+# and specify the fully qualified class name to the JavaScript interface
+# class:
+#-keepclassmembers class fqcn.of.javascript.interface.for.webview {
+#   public *;
+#}
+
+# Uncomment this to preserve the line number information for
+# debugging stack traces.
+#-keepattributes SourceFile,LineNumberTable
+
+# If you keep the line number information, uncomment this to
+# hide the original source file name.
+#-renamesourcefileattribute SourceFile

--- a/CrossAppLogin/src/main/kotlin/com/infomaniak/core/login/crossapp/BaseCrossAppLoginProvider.kt
+++ b/CrossAppLogin/src/main/kotlin/com/infomaniak/core/login/crossapp/BaseCrossAppLoginProvider.kt
@@ -1,0 +1,101 @@
+/*
+ * Infomaniak Core - Android
+ * Copyright (C) 2025 Infomaniak Network SA
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+@file:OptIn(ExperimentalSerializationApi::class)
+
+package com.infomaniak.core.login.crossapp
+
+import android.app.Service
+import android.content.ContentProvider
+import android.content.ContentValues
+import android.database.Cursor
+import android.net.Uri
+import android.os.Binder
+import android.os.Process
+import com.infomaniak.core.login.crossapp.internal.SingleBlobCursor
+import com.infomaniak.core.login.crossapp.internal.certificates.AppCertificateChecker
+import com.infomaniak.core.login.crossapp.internal.certificates.AppCertificateCheckerImpl
+import com.infomaniak.core.login.crossapp.internal.certificates.infomaniakAppsCertificates
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.*
+import kotlinx.coroutines.runBlocking
+import kotlinx.serialization.ExperimentalSerializationApi
+import kotlinx.serialization.encodeToByteArray
+import kotlinx.serialization.protobuf.ProtoBuf
+
+/**
+ * **NOTE**: This [ContentProvider] based approach might be used only for prototyping,
+ * and possibly not for the final version, where the bound [Service] based approach
+ * in [BaseCrossAppLoginService] might be favored for resource usage reasons.
+ */
+abstract class BaseCrossAppLoginProvider : ContentProvider() {
+
+    private val scope = CoroutineScope(Dispatchers.Default)
+
+    @ExperimentalSerializationApi
+    protected abstract val accountsFlow: Flow<List<ExternalAccount>>
+
+    private val certificateChecker: AppCertificateChecker = AppCertificateCheckerImpl(
+        signingCertificates = infomaniakAppsCertificates
+    )
+
+    private val accountsSharedFlow = accountsFlow.map { accounts ->
+        val byteArray = ProtoBuf.encodeToByteArray(accounts)
+        SingleBlobCursor(byteArray)
+    }.shareIn(
+        scope = scope,
+        started = SharingStarted.Lazily,
+        replay = 1
+    )
+
+    final override fun onCreate(): Boolean = true
+
+    final override fun query(
+        uri: Uri,
+        projection: Array<out String?>?,
+        selection: String?,
+        selectionArgs: Array<out String?>?,
+        sortOrder: String?
+    ): Cursor? {
+        val callingUid = Binder.getCallingUid()
+        check(callingUid != Process.myUid())
+        return runBlocking {
+            val allowed = certificateChecker.isUidAllowed(callingUid)
+            if (allowed) accountsSharedFlow.first() else throw SecurityException("The calling app wasn't recognized")
+        }
+    }
+
+    final override fun getType(uri: Uri): String? = null
+
+    final override fun insert(uri: Uri, values: ContentValues?) = unsupported()
+
+    final override fun delete(
+        uri: Uri,
+        selection: String?,
+        selectionArgs: Array<out String?>?
+    ) = unsupported()
+
+    final override fun update(
+        uri: Uri,
+        values: ContentValues?,
+        selection: String?,
+        selectionArgs: Array<out String?>?
+    ) = unsupported()
+
+    private fun unsupported(): Nothing = throw UnsupportedOperationException()
+}

--- a/CrossAppLogin/src/main/kotlin/com/infomaniak/core/login/crossapp/BaseCrossAppLoginService.kt
+++ b/CrossAppLogin/src/main/kotlin/com/infomaniak/core/login/crossapp/BaseCrossAppLoginService.kt
@@ -50,10 +50,6 @@ abstract class BaseCrossAppLoginService : LifecycleService() {
         signingCertificates = infomaniakAppsCertificates
     )
 
-    internal object MsgWhat {
-        const val GET_SNAPSHOT_OF_SIGNED_IN_ACCOUNTS = 0
-    }
-
     init {
         lifecycleScope.launch { handleIncomingMessages() }
     }
@@ -73,7 +69,7 @@ abstract class BaseCrossAppLoginService : LifecycleService() {
             disposableMessage.use { msg ->
                 check(msg.sendingUid != ourUid) // We are not supposed to talk to ourselves.
                 if (certificateChecker.isUidAllowed(msg.sendingUid)) when (msg.what) {
-                    MsgWhat.GET_SNAPSHOT_OF_SIGNED_IN_ACCOUNTS -> {
+                    IpcMessageWhat.GET_SNAPSHOT_OF_SIGNED_IN_ACCOUNTS -> {
                         val accountsData = accountsDataFlow.first()
                         val reply = Message.obtain().also { newMsg ->
                             newMsg.obj = accountsData
@@ -90,5 +86,9 @@ abstract class BaseCrossAppLoginService : LifecycleService() {
         }.onCompletion {
             messagesHandler.removeCallbacksAndMessages(null)
         }.collect()
+    }
+
+    internal object IpcMessageWhat {
+        const val GET_SNAPSHOT_OF_SIGNED_IN_ACCOUNTS = 0
     }
 }

--- a/CrossAppLogin/src/main/kotlin/com/infomaniak/core/login/crossapp/BaseCrossAppLoginService.kt
+++ b/CrossAppLogin/src/main/kotlin/com/infomaniak/core/login/crossapp/BaseCrossAppLoginService.kt
@@ -1,0 +1,94 @@
+/*
+ * Infomaniak Login - Android
+ * Copyright (C) 2025 Infomaniak Network SA
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@file:OptIn(ExperimentalSerializationApi::class)
+
+package com.infomaniak.core.login.crossapp
+
+import android.content.Intent
+import android.os.*
+import androidx.lifecycle.LifecycleService
+import androidx.lifecycle.lifecycleScope
+import com.infomaniak.core.login.crossapp.internal.ChannelMessageHandler
+import com.infomaniak.core.login.crossapp.internal.DisposableMessage
+import com.infomaniak.core.login.crossapp.internal.certificates.AppCertificateChecker
+import com.infomaniak.core.login.crossapp.internal.certificates.AppCertificateCheckerImpl
+import com.infomaniak.core.login.crossapp.internal.certificates.infomaniakAppsCertificates
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.flow.*
+import kotlinx.coroutines.invoke
+import kotlinx.coroutines.launch
+import kotlinx.serialization.ExperimentalSerializationApi
+import kotlinx.serialization.encodeToByteArray
+import kotlinx.serialization.protobuf.ProtoBuf
+
+abstract class BaseCrossAppLoginService : LifecycleService() {
+
+    @ExperimentalSerializationApi
+    protected abstract val accountsFlow: Flow<List<ExternalAccount>>
+
+    private val incomingMessagesChannel = Channel<DisposableMessage>(capacity = Channel.UNLIMITED)
+    private val messagesHandler = ChannelMessageHandler(incomingMessagesChannel)
+    private val messenger by lazy { Messenger(messagesHandler) }
+
+    private val certificateChecker: AppCertificateChecker = AppCertificateCheckerImpl(
+        signingCertificates = infomaniakAppsCertificates
+    )
+
+    internal object MsgWhat {
+        const val GET_SNAPSHOT_OF_SIGNED_IN_ACCOUNTS = 0
+    }
+
+    init {
+        lifecycleScope.launch { handleIncomingMessages() }
+    }
+
+    final override fun onBind(intent: Intent): IBinder? {
+        super.onBind(intent)
+        return messenger.binder
+    }
+
+    private suspend fun handleIncomingMessages() = Dispatchers.Default {
+        val ourUid = Process.myUid()
+        val protobuf = ProtoBuf
+        val accountsDataFlow: SharedFlow<ByteArray> = accountsFlow.map {
+            protobuf.encodeToByteArray(it)
+        }.shareIn(this, SharingStarted.Eagerly, replay = 1)
+        incomingMessagesChannel.consumeAsFlow().onEach { disposableMessage ->
+            disposableMessage.use { msg ->
+                check(msg.sendingUid != ourUid) // We are not supposed to talk to ourselves.
+                if (certificateChecker.isUidAllowed(msg.sendingUid)) when (msg.what) {
+                    MsgWhat.GET_SNAPSHOT_OF_SIGNED_IN_ACCOUNTS -> {
+                        val accountsData = accountsDataFlow.first()
+                        val reply = Message.obtain().also { newMsg ->
+                            newMsg.obj = accountsData
+                            newMsg.isAsynchronous = true
+                        }
+                        try {
+                            msg.replyTo.send(reply)
+                        } catch (_: DeadObjectException) {
+                            // The client app died before we could respond, we can safely ignore it.
+                        }
+                    }
+                }
+            }
+        }.onCompletion {
+            messagesHandler.removeCallbacksAndMessages(null)
+        }.collect()
+    }
+}

--- a/CrossAppLogin/src/main/kotlin/com/infomaniak/core/login/crossapp/BaseCrossAppLoginService.kt
+++ b/CrossAppLogin/src/main/kotlin/com/infomaniak/core/login/crossapp/BaseCrossAppLoginService.kt
@@ -61,10 +61,10 @@ abstract class BaseCrossAppLoginService : LifecycleService() {
 
     private suspend fun handleIncomingMessages() = Dispatchers.Default {
         val ourUid = Process.myUid()
-        val protobuf = ProtoBuf
-        val accountsDataFlow: SharedFlow<ByteArray> = localAccountsFlow(selectedUserIdFlow).map {
-            protobuf.encodeToByteArray(it)
-        }.shareIn(this, SharingStarted.Eagerly, replay = 1)
+        val accountsDataFlow: SharedFlow<ByteArray> = localAccountsFlow(selectedUserIdFlow)
+            .map { ProtoBuf.Default.encodeToByteArray(it) }
+            .shareIn(this, SharingStarted.Eagerly, replay = 1)
+
         incomingMessagesChannel.consumeAsFlow().onEach { disposableMessage ->
             disposableMessage.use { msg ->
                 check(msg.sendingUid != ourUid) // We are not supposed to talk to ourselves.

--- a/CrossAppLogin/src/main/kotlin/com/infomaniak/core/login/crossapp/BaseCrossAppLoginService.kt
+++ b/CrossAppLogin/src/main/kotlin/com/infomaniak/core/login/crossapp/BaseCrossAppLoginService.kt
@@ -68,7 +68,8 @@ abstract class BaseCrossAppLoginService : LifecycleService() {
         incomingMessagesChannel.consumeAsFlow().onEach { disposableMessage ->
             disposableMessage.use { msg ->
                 check(msg.sendingUid != ourUid) // We are not supposed to talk to ourselves.
-                if (certificateChecker.isUidAllowed(msg.sendingUid)) when (msg.what) {
+                if (certificateChecker.isUidAllowed(msg.sendingUid).not()) return@use
+                when (msg.what) {
                     IpcMessageWhat.GET_SNAPSHOT_OF_SIGNED_IN_ACCOUNTS -> {
                         val accountsData = accountsDataFlow.first()
                         val reply = Message.obtain().also { newMsg ->

--- a/CrossAppLogin/src/main/kotlin/com/infomaniak/core/login/crossapp/BaseCrossAppLoginService.kt
+++ b/CrossAppLogin/src/main/kotlin/com/infomaniak/core/login/crossapp/BaseCrossAppLoginService.kt
@@ -69,6 +69,7 @@ abstract class BaseCrossAppLoginService : LifecycleService() {
             disposableMessage.use { msg ->
                 check(msg.sendingUid != ourUid) // We are not supposed to talk to ourselves.
                 if (certificateChecker.isUidAllowed(msg.sendingUid).not()) return@use
+
                 when (msg.what) {
                     IpcMessageWhat.GET_SNAPSHOT_OF_SIGNED_IN_ACCOUNTS -> {
                         sendSignedInAccountsToApp(

--- a/CrossAppLogin/src/main/kotlin/com/infomaniak/core/login/crossapp/CrossAppLogin.kt
+++ b/CrossAppLogin/src/main/kotlin/com/infomaniak/core/login/crossapp/CrossAppLogin.kt
@@ -1,0 +1,27 @@
+/*
+ * Infomaniak Login - Android
+ * Copyright (C) 2025 Infomaniak Network SA
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.infomaniak.core.login.crossapp
+
+import kotlinx.serialization.ExperimentalSerializationApi
+
+sealed interface CrossAppLogin {
+
+    @ExperimentalSerializationApi
+    suspend fun retrieveAccountsFromOtherApps(): List<ExternalAccount>
+
+}

--- a/CrossAppLogin/src/main/kotlin/com/infomaniak/core/login/crossapp/ExternalAccount.kt
+++ b/CrossAppLogin/src/main/kotlin/com/infomaniak/core/login/crossapp/ExternalAccount.kt
@@ -1,0 +1,37 @@
+/*
+ * Infomaniak Login - Android
+ * Copyright (C) 2025-2025 Infomaniak Network SA
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.infomaniak.core.login.crossapp
+
+import kotlinx.serialization.ExperimentalSerializationApi
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.protobuf.ProtoNumber
+
+@ExperimentalSerializationApi
+@Serializable
+data class ExternalAccount(
+    @ProtoNumber(1)
+    val fullName: String,
+    @ProtoNumber(2)
+    val email: String,
+    @ProtoNumber(3)
+    val avatarUrl: String? = null,
+    @ProtoNumber(4)
+    val isCurrentlySelectedInAnApp: Boolean,
+    @ProtoNumber(5)
+    val tokens: Set<String>
+)

--- a/CrossAppLogin/src/main/kotlin/com/infomaniak/core/login/crossapp/ExternalAccount.kt
+++ b/CrossAppLogin/src/main/kotlin/com/infomaniak/core/login/crossapp/ExternalAccount.kt
@@ -21,6 +21,20 @@ import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.protobuf.ProtoNumber
 
+/**
+ * ## Important message to editors
+ *
+ * For all existing Unless the given field never made it to a public release (which includes betas!):
+ * - **NEVER** change the type of an existing field.
+ * - **NEVER** change the value in the `@ProtoNumber` of an existing field.
+ * - **NEVER** remove a field that was present before.
+ * - **NEVER** reuse a protobuf number. Those shall be unique and stable, essentially forever.
+ * - **Safe changes:**
+ *    1. Renaming any existing field.
+ *    2. Adding new fields with explicit `@ProtoNumber` using a new, never used number.
+ *    3. Deprecating any field (without touching its `@ProtoNumber`).
+ *    4. Rename this data class.
+ */
 @ExperimentalSerializationApi
 @Serializable
 data class ExternalAccount(

--- a/CrossAppLogin/src/main/kotlin/com/infomaniak/core/login/crossapp/internal/ChannelMessageHandler.kt
+++ b/CrossAppLogin/src/main/kotlin/com/infomaniak/core/login/crossapp/internal/ChannelMessageHandler.kt
@@ -1,0 +1,42 @@
+/*
+ * Infomaniak Login - Android
+ * Copyright (C) 2025-2025 Infomaniak Network SA
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.infomaniak.core.login.crossapp.internal
+
+import android.os.Handler
+import android.os.Message
+import kotlinx.coroutines.channels.SendChannel
+import splitties.mainthread.mainLooper
+import java.lang.ref.WeakReference
+
+/**
+ * A Handler that sends everything it receives to the passed [channel], as a copy.
+ * The channel is held in a WeakReference to avoid Handler leak.
+ *
+ * Used for IPC (inter-process communication)
+ */
+internal class ChannelMessageHandler(channel: SendChannel<DisposableMessage>) : Handler(mainLooper) {
+
+    private val weakChannelReference = WeakReference(channel)
+
+    override fun handleMessage(msg: Message) {
+        weakChannelReference.get()?.let { channel ->
+            val disposableMessage = DisposableMessage.Companion.fromCopy(msg, recycleOriginalMessage = true)
+            channel.trySend(disposableMessage)
+        }
+    }
+}

--- a/CrossAppLogin/src/main/kotlin/com/infomaniak/core/login/crossapp/internal/DisposableMessage.kt
+++ b/CrossAppLogin/src/main/kotlin/com/infomaniak/core/login/crossapp/internal/DisposableMessage.kt
@@ -1,0 +1,49 @@
+/*
+ * Infomaniak Login - Android
+ * Copyright (C) 2025-2025 Infomaniak Network SA
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@file:OptIn(ExperimentalContracts::class)
+
+package com.infomaniak.core.login.crossapp.internal
+
+import android.os.Message
+import kotlin.contracts.ExperimentalContracts
+import kotlin.contracts.InvocationKind
+import kotlin.contracts.contract
+
+@JvmInline
+internal value class DisposableMessage private constructor(private val message: Message) {
+
+    companion object {
+        fun fromCopy(
+            originalMessage: Message,
+            recycleOriginalMessage: Boolean
+        ): DisposableMessage {
+            val copiedMessage = Message.obtain(originalMessage)
+            if (recycleOriginalMessage) originalMessage.recycle()
+            return DisposableMessage(copiedMessage)
+        }
+    }
+
+    inline fun <R> use(block: (msg: Message) -> R): R {
+        contract { callsInPlace(block, InvocationKind.EXACTLY_ONCE) }
+        return try {
+            block(message)
+        } finally {
+            message.recycle()
+        }
+    }
+}

--- a/CrossAppLogin/src/main/kotlin/com/infomaniak/core/login/crossapp/internal/LocalAccounts.kt
+++ b/CrossAppLogin/src/main/kotlin/com/infomaniak/core/login/crossapp/internal/LocalAccounts.kt
@@ -1,0 +1,43 @@
+/*
+ * Infomaniak Core - Android
+ * Copyright (C) 2025 Infomaniak Network SA
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.infomaniak.core.login.crossapp.internal
+
+import com.infomaniak.core.login.crossapp.ExternalAccount
+import com.infomaniak.lib.core.models.user.User
+import com.infomaniak.lib.core.room.UserDatabase
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.combine
+import kotlinx.serialization.ExperimentalSerializationApi
+
+@ExperimentalSerializationApi
+internal fun localAccountsFlow(currentUserIdFlow: Flow<Int>): Flow<List<ExternalAccount>> {
+    return combine(
+        UserDatabase().userDao().allUsers,
+        currentUserIdFlow
+    ) { allUsers: List<User>, currentUserId: Int ->
+        allUsers.map { user ->
+            ExternalAccount(
+                fullName = user.displayName ?: user.run { "$firstname $lastname" },
+                email = user.email,
+                avatarUrl = user.avatar,
+                isCurrentlySelectedInAnApp = user.id == currentUserId,
+                tokens = setOf(user.apiToken.accessToken),
+            )
+        }
+    }
+}

--- a/CrossAppLogin/src/main/kotlin/com/infomaniak/core/login/crossapp/internal/SingleBlobCursor.kt
+++ b/CrossAppLogin/src/main/kotlin/com/infomaniak/core/login/crossapp/internal/SingleBlobCursor.kt
@@ -1,0 +1,43 @@
+/*
+ * Infomaniak Core - Android
+ * Copyright (C) 2025 Infomaniak Network SA
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.infomaniak.core.login.crossapp.internal
+
+import android.database.AbstractCursor
+
+internal class SingleBlobCursor(private val data: ByteArray) : AbstractCursor() {
+
+    override fun getCount(): Int = 1
+
+    override fun getColumnNames(): Array<out String?>? = dummyColumnNames
+
+    override fun getBlob(column: Int): ByteArray = data
+
+    override fun getString(column: Int) = unsupported()
+    override fun getShort(column: Int) = unsupported()
+    override fun getInt(column: Int) = unsupported()
+    override fun getLong(column: Int) = unsupported()
+    override fun getFloat(column: Int) = unsupported()
+    override fun getDouble(column: Int) = unsupported()
+    override fun isNull(column: Int) = unsupported()
+
+    private fun unsupported(): Nothing = throw UnsupportedOperationException()
+
+    private companion object {
+        private val dummyColumnNames = arrayOf("")
+    }
+}

--- a/CrossAppLogin/src/main/kotlin/com/infomaniak/core/login/crossapp/internal/certificates/AppCertificateChecker.kt
+++ b/CrossAppLogin/src/main/kotlin/com/infomaniak/core/login/crossapp/internal/certificates/AppCertificateChecker.kt
@@ -17,7 +17,7 @@
 
 package com.infomaniak.core.login.crossapp.internal.certificates
 
-internal interface AppCertificateChecker {
+internal sealed interface AppCertificateChecker {
 
     suspend fun isUidAllowed(uid: Int): Boolean
 }

--- a/CrossAppLogin/src/main/kotlin/com/infomaniak/core/login/crossapp/internal/certificates/AppCertificateChecker.kt
+++ b/CrossAppLogin/src/main/kotlin/com/infomaniak/core/login/crossapp/internal/certificates/AppCertificateChecker.kt
@@ -1,0 +1,23 @@
+/*
+ * Infomaniak Login - Android
+ * Copyright (C) 2025-2025 Infomaniak Network SA
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.infomaniak.core.login.crossapp.internal.certificates
+
+internal interface AppCertificateChecker {
+
+    suspend fun isUidAllowed(uid: Int): Boolean
+}

--- a/CrossAppLogin/src/main/kotlin/com/infomaniak/core/login/crossapp/internal/certificates/AppCertificateCheckerImpl.kt
+++ b/CrossAppLogin/src/main/kotlin/com/infomaniak/core/login/crossapp/internal/certificates/AppCertificateCheckerImpl.kt
@@ -39,7 +39,7 @@ internal class AppCertificateCheckerImpl(
     )
 
     override suspend fun isUidAllowed(uid: Int): Boolean {
-        if (uid == -1) return false
+        if (uid == -1) return false // -1 means the message is invalid, see android.os.Message.sendingUid Javadoc.
         return allowedUids.useElement(key = uid) { it.await() }
     }
 

--- a/CrossAppLogin/src/main/kotlin/com/infomaniak/core/login/crossapp/internal/certificates/AppCertificateCheckerImpl.kt
+++ b/CrossAppLogin/src/main/kotlin/com/infomaniak/core/login/crossapp/internal/certificates/AppCertificateCheckerImpl.kt
@@ -1,0 +1,109 @@
+/*
+ * Infomaniak Login - Android
+ * Copyright (C) 2025-2025 Infomaniak Network SA
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@file:OptIn(ExperimentalSplittiesApi::class)
+
+package com.infomaniak.core.login.crossapp.internal.certificates
+
+import android.content.pm.PackageManager
+import android.content.pm.Signature
+import android.os.Build.VERSION.SDK_INT
+import com.infomaniak.core.DynamicLazyMap
+import kotlinx.coroutines.*
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.update
+import splitties.coroutines.launchRacer
+import splitties.coroutines.race
+import splitties.coroutines.raceOf
+import splitties.experimental.ExperimentalSplittiesApi
+import splitties.init.appCtx
+
+internal class AppCertificateCheckerImpl(
+    private val signingCertificates: AppSigningCertificates
+) : AppCertificateChecker {
+
+    private val packageManager = appCtx.packageManager
+    private val allowedUids = DynamicLazyMap<Int, Deferred<Boolean>>(
+        cacheManager = { _, _ -> awaitCancellation() },
+        createElement = { uid -> async { checkIfUidShouldBeAllowed(uid) } }
+    )
+
+    override suspend fun isUidAllowed(uid: Int): Boolean {
+        if (uid == -1) return false
+        return allowedUids.useElement(key = uid) { it.await() }
+    }
+
+    private suspend fun checkIfUidShouldBeAllowed(uid: Int): Boolean {
+        val packages = Dispatchers.IO { packageManager.getPackagesForUid(uid) } ?: return false
+
+        val finishedCheckers = MutableStateFlow(0)
+        return race {
+            packages.forEach { packageToCheck ->
+                launchRacer {
+                    val allowed = checkIfPackageMatchesAnyCertificate(packageToCheck)
+                    if (!allowed) {
+                        finishedCheckers.update { it + 1 }
+                        awaitCancellation()
+                    }
+                    true
+                }
+            }
+            launchRacer {
+                finishedCheckers.first { it == packages.size }
+                false
+            }
+        }
+    }
+
+    private suspend fun checkIfPackageMatchesAnyCertificate(targetPackageName: String): Boolean {
+        val signatures: List<Signature> = if (SDK_INT >= 28) {
+            val pkgInfo = Dispatchers.IO {
+                packageManager.getPackageInfo(targetPackageName, PackageManager.GET_SIGNING_CERTIFICATES)
+            }
+            val signingInfo = pkgInfo?.signingInfo
+            when {
+                signingInfo == null -> emptyList()
+                signingInfo.hasMultipleSigners() -> signingInfo.apkContentsSigners.asList()
+                else -> signingInfo.signingCertificateHistory.asList()
+            }
+        } else @Suppress("Deprecation") {
+            val pkgInfo = Dispatchers.IO {
+                packageManager.getPackageInfo(targetPackageName, PackageManager.GET_SIGNATURES)
+            }
+            pkgInfo?.signatures?.asList() ?: emptyList()
+        }
+        if (signatures.isEmpty()) return false
+
+        val matchedCompletable: CompletableJob = Job()
+        return raceOf({
+            matchedCompletable.join()
+            true
+        },  {
+            signatures.forEach {
+                async {
+                    val matches = signingCertificates.matches(targetPackageName = targetPackageName, signingCertificate = it)
+                    if (matches) {
+                        matchedCompletable.complete()
+                        awaitCancellation()
+                    }
+                }
+            }
+            false // Will not be accepted if there's a match since we'd awaitCancellation for one of the child coroutines.
+        })
+    }
+}

--- a/CrossAppLogin/src/main/kotlin/com/infomaniak/core/login/crossapp/internal/certificates/AppSigningCertificates.kt
+++ b/CrossAppLogin/src/main/kotlin/com/infomaniak/core/login/crossapp/internal/certificates/AppSigningCertificates.kt
@@ -1,0 +1,40 @@
+/*
+ * Infomaniak Login - Android
+ * Copyright (C) 2025 Infomaniak Network SA
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.infomaniak.core.login.crossapp.internal.certificates
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.invoke
+import java.security.MessageDigest
+import android.content.pm.Signature as SigningCertificate
+
+internal class AppSigningCertificates(
+    builderAction: MutableMap<String, Set<LazyAppSigningCertificate>>.() -> Unit
+) {
+
+    private val certificatesMapForPackages: Map<String, Set<LazyAppSigningCertificate>> = buildMap(builderAction)
+
+    suspend fun matches(targetPackageName: String, signingCertificate: SigningCertificate): Boolean {
+        val acceptedCertificates = certificatesMapForPackages[targetPackageName] ?: return false
+        return Dispatchers.Default {
+            val givenSha256 = signingCertificate.sha256()
+            acceptedCertificates.any { it.matches(givenSha256) }
+        }
+    }
+
+    private fun SigningCertificate.sha256(): ByteArray = MessageDigest.getInstance("SHA-256").digest(toByteArray())
+}

--- a/CrossAppLogin/src/main/kotlin/com/infomaniak/core/login/crossapp/internal/certificates/LazyAppSigningCertificate.kt
+++ b/CrossAppLogin/src/main/kotlin/com/infomaniak/core/login/crossapp/internal/certificates/LazyAppSigningCertificate.kt
@@ -1,0 +1,32 @@
+/*
+ * Infomaniak Login - Android
+ * Copyright (C) 2025-2025 Infomaniak Network SA
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.infomaniak.core.login.crossapp.internal.certificates
+
+/**
+ * The [getSha256Fingerprint] lambda return value can include the colon separator (`:`),
+ * and can be uppercase (this is what the Play Store returns).
+ */
+internal class LazyAppSigningCertificate(getSha256Fingerprint: () -> String) {
+
+    private val sha256FingerprintString by lazy { getSha256Fingerprint().replace(":", "").lowercase() }
+
+    @OptIn(ExperimentalStdlibApi::class)
+    private val sha256Fingerprint: ByteArray by lazy { sha256FingerprintString.hexToByteArray() }
+
+    fun matches(expectedSha256: ByteArray): Boolean = sha256Fingerprint contentEquals expectedSha256
+}

--- a/CrossAppLogin/src/main/kotlin/com/infomaniak/core/login/crossapp/internal/certificates/infomaniakAppsCertificates.kt
+++ b/CrossAppLogin/src/main/kotlin/com/infomaniak/core/login/crossapp/internal/certificates/infomaniakAppsCertificates.kt
@@ -1,0 +1,28 @@
+/*
+ * Infomaniak Login - Android
+ * Copyright (C) 2025-2025 Infomaniak Network SA
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.infomaniak.core.login.crossapp.internal.certificates
+
+internal val infomaniakAppsCertificates = AppSigningCertificates {
+    this["com.infomaniak.drive"] = setOf(
+        LazyAppSigningCertificate { "72:C2:E2:2D:56:BA:86:07:C4:D5:A0:95:ED:97:7B:A5:F5:D1:C6:0A:AF:39:C3:3D:E2:33:BE:77:CB:0F:37:78" },
+    )
+    this["com.infomaniak.mail"] = setOf(
+        LazyAppSigningCertificate { "54:CE:26:CB:66:CB:12:EE:E6:FF:51:04:C9:5A:C4:1C:F1:93:9D:B9:C1:83:13:13:AA:52:3D:41:D7:29:EC:C2" },
+    )
+    //TODO: Add other Infomaniak apps that are expected to support cross-app login.
+}

--- a/Legacy/build.gradle
+++ b/Legacy/build.gradle
@@ -71,7 +71,8 @@ dependencies {
     api "androidx.appcompat:appcompat:$appcompatVersion"
     api "androidx.appcompat:appcompat-resources:$appcompatVersion"
 
-    implementation "com.louiscad.splitties:splitties-appctx:3.0.0"
+    def splittiesVersion = "3.0.0"
+    implementation "com.louiscad.splitties:splitties-appctx:$splittiesVersion"
 
     def roomVersion = '2.7.1'
     api "androidx.room:room-ktx:$roomVersion"

--- a/Legacy/src/main/java/com/infomaniak/lib/core/room/UserDao.kt
+++ b/Legacy/src/main/java/com/infomaniak/lib/core/room/UserDao.kt
@@ -20,11 +20,15 @@ package com.infomaniak.lib.core.room
 import androidx.lifecycle.LiveData
 import androidx.room.*
 import com.infomaniak.lib.core.models.user.User
+import kotlinx.coroutines.flow.Flow
 
 @Dao
 interface UserDao {
     @Query("SELECT * FROM user")
     fun getAll(): LiveData<List<User>>
+
+    @get:Query("SELECT * FROM user")
+    val allUsers: Flow<List<User>>
 
     @Query("SELECT * FROM user")
     fun getAllSync(): List<User>

--- a/Legacy/src/main/java/com/infomaniak/lib/core/room/UserDatabase.kt
+++ b/Legacy/src/main/java/com/infomaniak/lib/core/room/UserDatabase.kt
@@ -15,6 +15,8 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
+@file:Suppress("NOTHING_TO_INLINE")
+
 package com.infomaniak.lib.core.room
 
 import androidx.room.*
@@ -45,28 +47,24 @@ import splitties.init.appCtx
     exportSchema = true
 )
 @TypeConverters(UserConverter::class)
-abstract class UserDatabase : RoomDatabase() {
+abstract class UserDatabase internal constructor(): RoomDatabase() {
 
     abstract fun userDao(): UserDao
 
     companion object {
-        @Volatile
-        private var INSTANCE: UserDatabase? = null
 
-        fun getDatabase(): UserDatabase {
-            return INSTANCE ?: synchronized(this) {
-                val instance = Room.databaseBuilder(
-                    context = appCtx,
-                    klass = UserDatabase::class.java,
-                    name = "user_database"
-                ).apply {
-                    enableMultiInstanceInvalidation()
-                    fallbackToDestructiveMigration(true)
-                }.build()
-                INSTANCE = instance
-                instance
-            }
-        }
+        inline operator fun invoke(): UserDatabase = instance
+
+        fun getDatabase(): UserDatabase = instance
+
+        @PublishedApi
+        internal val instance = Room.databaseBuilder<UserDatabase>(
+            context = appCtx,
+            name = "user_database"
+        ).apply {
+            enableMultiInstanceInvalidation()
+            fallbackToDestructiveMigration(dropAllTables = true)
+        }.build()
     }
 }
 

--- a/gradle/core.versions.toml
+++ b/gradle/core.versions.toml
@@ -14,7 +14,7 @@ junit = "4.13" # Don't update this because it breaks tests
 junitAndroidx = "1.2.1"
 kotest = "5.9.1"
 kotlinxCoroutines = "1.10.2"
-kotlinxSerializationJson = "1.8.1"
+kotlinxSerialization = "1.8.1"
 ktor = "3.0.3"
 lifecycleRuntimeKtx = "2.8.7" # Waiting for SDK 35 to update to 2.9.0+
 material = "1.12.0"
@@ -50,7 +50,8 @@ integrity = { module = "com.google.android.play:integrity", version.ref = "integ
 kotest-assertions = { module = "io.kotest:kotest-assertions-core", version.ref = "kotest" }
 kotlinx-coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "kotlinxCoroutines" }
 kotlinx-coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "kotlinxCoroutines" }
-kotlinx-serialization-json = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "kotlinxSerializationJson" }
+kotlinx-serialization-json = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "kotlinxSerialization" }
+kotlinx-serialization-protobuf = { module = "org.jetbrains.kotlinx:kotlinx-serialization-protobuf", version.ref = "kotlinxSerialization" }
 ktor-client-content-negociation = { module = "io.ktor:ktor-client-content-negotiation", version.ref = "ktor" }
 ktor-client-core = { module = "io.ktor:ktor-client-core", version.ref = "ktor" }
 ktor-client-encoding = { module = "io.ktor:ktor-client-encoding", version.ref = "ktor" }

--- a/src/main/kotlin/com/infomaniak/core/Flow.kt
+++ b/src/main/kotlin/com/infomaniak/core/Flow.kt
@@ -20,6 +20,7 @@
 package com.infomaniak.core
 
 import android.os.SystemClock
+import kotlinx.coroutines.CloseableCoroutineDispatcher
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.delay
@@ -49,3 +50,28 @@ fun <T> Flow<T>.rateLimit(minInterval: Duration): Flow<T> = channelFlow {
         lastEmitElapsedNanos = SystemClock.elapsedRealtimeNanos()
     }
 }.buffer(Channel.RENDEZVOUS)
+
+/**
+ * Similar to [flowOn], but will lazily create the Dispatcher returned by
+ * [createDispatcher], and will close it once the flow is cancelled or completes.
+ *
+ * Example usage:
+ * ```
+ * val someDataFlow: Flow<Something> = flow {
+ *     val flow = getSomeDatabaseInstance()
+ *         .someQuery()
+ *         .toFlow()
+ *         .map { it?.toSomethingElse() }
+ *     emitAll(flow)
+ * }.flowOnLazyClosable {
+ *     newSingleThreadContext("someData")
+ * }
+ * ```
+ */
+fun <T> Flow<T>.flowOnLazyClosable(
+    createDispatcher: () -> CloseableCoroutineDispatcher
+) : Flow<T> = flow {
+    createDispatcher().use { dispatcher ->
+        emitAll(flowOn(dispatcher))
+    }
+}

--- a/src/main/kotlin/com/infomaniak/core/Racing.kt
+++ b/src/main/kotlin/com/infomaniak/core/Racing.kt
@@ -39,11 +39,10 @@ suspend fun <R> completableScope(
     ) -> R
 ): R {
     val deferred = CompletableDeferred<R>()
-    return raceOf({
-        deferred.await()
-    }, {
-        block(Completable(deferred))
-    })
+    return raceOf(
+        { deferred.await() },
+        { block(Completable(deferred)) },
+    )
 }
 
 @JvmInline

--- a/src/main/kotlin/com/infomaniak/core/Racing.kt
+++ b/src/main/kotlin/com/infomaniak/core/Racing.kt
@@ -1,0 +1,56 @@
+/*
+ * Infomaniak Core - Android
+ * Copyright (C) 2025 Infomaniak Network SA
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+@file:OptIn(ExperimentalSplittiesApi::class)
+
+package com.infomaniak.core
+
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.awaitCancellation
+import splitties.coroutines.raceOf
+import splitties.experimental.ExperimentalSplittiesApi
+
+/**
+ * This function will end if either:
+ * a. the [Completable] passed to the [block] has its [Completable.complete] function called.
+ * b. the passed [block] and all the coroutines launched in its scope are complete.
+ *
+ * In the case `a` (call to [Completable.complete]), [block] will be cancelled, along with
+ * all its child coroutines.
+ */
+suspend fun <R> completableScope(
+    block: suspend CoroutineScope.(
+        completable: Completable<R>
+    ) -> R
+): R {
+    val deferred = CompletableDeferred<R>()
+    return raceOf({
+        deferred.await()
+    }, {
+        block(Completable(deferred))
+    })
+}
+
+@JvmInline
+value class Completable<T> internal constructor(private val deferred: CompletableDeferred<T>) {
+
+    suspend fun complete(value: T): Nothing {
+        deferred.complete(value)
+        awaitCancellation()
+    }
+}

--- a/src/main/kotlin/com/infomaniak/core/Racing.kt
+++ b/src/main/kotlin/com/infomaniak/core/Racing.kt
@@ -27,8 +27,8 @@ import splitties.experimental.ExperimentalSplittiesApi
 
 /**
  * This function will end if either:
- * a. the [Completable] passed to the [block] has its [Completable.complete] function called.
- * b. the passed [block] and all the coroutines launched in its scope are complete.
+ * 1. the [Completable] passed to the [block] has its [Completable.complete] function called.
+ * 2. the passed [block] and all the coroutines launched in its scope are complete.
  *
  * In the case `a` (call to [Completable.complete]), [block] will be cancelled, along with
  * all its child coroutines.


### PR DESCRIPTION
For the curious minds, [here is the doc on bound services](https://developer.android.com/develop/background-work/services/bound-services), one the ways to do IPC (inter-process communication) on Android.

Another way is using `ContentProvider`, which is also prototyped in this PR.