### PR TITLE
fix: Don't replace api error on correctly formed 'ApiResponse'

### DIFF
--- a/Legacy/src/main/java/com/infomaniak/lib/core/api/ApiController.kt
+++ b/Legacy/src/main/java/com/infomaniak/lib/core/api/ApiController.kt
@@ -233,7 +233,6 @@ object ApiController {
         if (apiResponse is ApiResponse<*> && apiResponse.result == ERROR) {
             @Suppress("DEPRECATION")
             apiResponse.translatedError = InternalTranslatedErrorCode.UnknownError.translateRes
-            apiResponse.error = InternalTranslatedErrorCode.UnknownError.toApiError()
         }
 
         return apiResponse

--- a/Legacy/src/main/java/com/infomaniak/lib/core/models/ApiResponse.kt
+++ b/Legacy/src/main/java/com/infomaniak/lib/core/models/ApiResponse.kt
@@ -17,10 +17,12 @@
  */
 package com.infomaniak.lib.core.models
 
+import androidx.annotation.StringRes
 import com.google.gson.annotations.SerializedName
 import kotlinx.parcelize.RawValue
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.Transient
 
 @Serializable
 open class ApiResponse<T>(
@@ -39,6 +41,8 @@ open class ApiResponse<T>(
                 "InfomaniakCore.apiErrorCodes. Use translateError() instead",
         ReplaceWith("translateError()", "com.infomaniak.lib.core.utils.ApiErrorCode.Companion.translateError"),
     )
+    @StringRes
+    @Transient
     var translatedError: Int = 0,
     @SerialName("items_per_page")
     @SerializedName("items_per_page")


### PR DESCRIPTION
All `ApiError` was overridden by `UnknownError` when receiving correctly formed error response and if error code was under `500`.