### PR TITLE
chore: Update malformed english translation

### DIFF
--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -25,6 +25,6 @@
     <string name="buttonSave">Save</string>
     <string name="buttonYes">Yes</string>
     <string name="errorDownload">Download error</string>
-    <string name="errorDownloadInsufficientSpace">Cannot download : Insufficient space</string>
+    <string name="errorDownloadInsufficientSpace">Cannot download: Insufficient space</string>
     <string name="reviewAlertTitle">Do you like %s?</string>
 </resources>


### PR DESCRIPTION
There's no space in english before `:`. I just happened to find that this string had this issue and it was already fixed on loco