### PR TITLE
refactor: Remove unnecessary kotlinCompilerExtensionVersion

### DIFF
--- a/Compose/Basics/build.gradle.kts
+++ b/Compose/Basics/build.gradle.kts
@@ -32,9 +32,6 @@ android {
     buildFeatures {
         compose = true
     }
-    composeOptions {
-        kotlinCompilerExtensionVersion = "1.5.14"
-    }
     kotlinOptions {
         jvmTarget = javaVersion.toString()
     }

--- a/Compose/MaterialThemeFromXml/build.gradle.kts
+++ b/Compose/MaterialThemeFromXml/build.gradle.kts
@@ -42,10 +42,6 @@ android {
         compose = true
     }
 
-    composeOptions {
-        kotlinCompilerExtensionVersion = "1.5.14"
-    }
-
     kotlinOptions {
         jvmTarget = javaVersion.toString()
     }

--- a/FileTypes/build.gradle.kts
+++ b/FileTypes/build.gradle.kts
@@ -35,9 +35,6 @@ android {
     buildFeatures {
         compose = true
     }
-    composeOptions {
-        kotlinCompilerExtensionVersion = "1.5.14"
-    }
 }
 
 dependencies {

--- a/Onboarding/build.gradle.kts
+++ b/Onboarding/build.gradle.kts
@@ -32,9 +32,6 @@ android {
     buildFeatures {
         compose = true
     }
-    composeOptions {
-        kotlinCompilerExtensionVersion = "1.5.14"
-    }
     kotlinOptions {
         jvmTarget = javaVersion.toString()
     }

--- a/Thumbnails/build.gradle.kts
+++ b/Thumbnails/build.gradle.kts
@@ -30,9 +30,6 @@ android {
     kotlinOptions {
         jvmTarget = javaVersion.toString()
     }
-    composeOptions {
-        kotlinCompilerExtensionVersion = "1.5.14"
-    }
 }
 
 dependencies {


### PR DESCRIPTION
Since kotlin 2.0, this is not needed anymore. Thanks @LouisCAD for the notice