### PR TITLE
chore: Revert re-adding of the Context parameter

### DIFF
--- a/Legacy/src/main/java/com/infomaniak/lib/core/room/UserDatabase.kt
+++ b/Legacy/src/main/java/com/infomaniak/lib/core/room/UserDatabase.kt
@@ -17,7 +17,6 @@
  */
 package com.infomaniak.lib.core.room
 
-import android.content.Context
 import androidx.room.AutoMigration
 import androidx.room.Database
 import androidx.room.Room
@@ -31,6 +30,7 @@ import com.infomaniak.lib.core.models.user.Email
 import com.infomaniak.lib.core.models.user.Phone
 import com.infomaniak.lib.core.models.user.User
 import com.infomaniak.lib.core.models.user.preferences.security.AuthDevices
+import splitties.init.appCtx
 
 @Database(
     entities = [User::class],
@@ -58,10 +58,10 @@ abstract class UserDatabase : RoomDatabase() {
         @Volatile
         private var INSTANCE: UserDatabase? = null
 
-        fun getDatabase(context: Context): UserDatabase {
+        fun getDatabase(): UserDatabase {
             return INSTANCE ?: synchronized(this) {
                 val instance = Room.databaseBuilder(
-                    context = context,
+                    context = appCtx,
                     klass = UserDatabase::class.java,
                     name = "user_database"
                 ).apply {


### PR DESCRIPTION
The problem will be fixed by adding an `injectAsAppCtx()` call in the Application class' init block.