### PR TITLE
refactor: Replace start mode from Lazily to Eagerly

### DIFF
--- a/Legacy/src/main/java/com/infomaniak/lib/core/auth/TokenInterceptorListener.kt
+++ b/Legacy/src/main/java/com/infomaniak/lib/core/auth/TokenInterceptorListener.kt
@@ -48,5 +48,5 @@ interface TokenInterceptorListener {
             // Let user retry without logging him out.
             // If we send null, the user will be logged out.
         }
-        .shareIn(coroutineScope, SharingStarted.Lazily, replay = 1)
+        .shareIn(coroutineScope, SharingStarted.Eagerly, replay = 1)
 }


### PR DESCRIPTION
Now, on projects, we make `by lazy` because we want to be able to do the init only when it's really useful.
So putting `Lazy` here becomes redundant and useless.