### PR TITLE
chore: Revert WorkManager cancelAllWork and pruneWork

### DIFF
--- a/CrossAppLogin/src/main/kotlin/com/infomaniak/core/login/crossapp/internal/deviceinfo/DeviceInfoUpdateManager.kt
+++ b/CrossAppLogin/src/main/kotlin/com/infomaniak/core/login/crossapp/internal/deviceinfo/DeviceInfoUpdateManager.kt
@@ -92,9 +92,6 @@ class DeviceInfoUpdateManager private constructor() {
 
     suspend inline fun <reified T : AbstractDeviceInfoUpdateWorker> scheduleWorkerOnDeviceInfoUpdate(): Nothing = Dispatchers.Default {
         val crossAppLogin = CrossAppLogin.Companion.forContext(context = appCtx, coroutineScope = this)
-        val workManager = WorkManager.getInstance(appCtx)
-        workManager.cancelAllWork().await()
-        workManager.pruneWork().await()
         crossAppLogin.sharedDeviceIdFlow.collectLatest { currentCrossAppDeviceId ->
             val userIdsFlow = UserDatabase().userDao().allUsers.map { users -> users.map { it.id } }.distinctUntilChanged()
             userIdsFlow.collect { userIds ->


### PR DESCRIPTION
These were helpful to test things, but we don't want them in production