### PR TITLE
refactor: Replace UserAvatar module with Avatar

### DIFF
--- a/MyKSuite/build.gradle.kts
+++ b/MyKSuite/build.gradle.kts
@@ -49,14 +49,17 @@ android {
 dependencies {
 
     implementation(project(":Core"))
+    implementation(project(":Core:Avatar"))
     implementation(project(":Core:Compose:Margin"))
     implementation(project(":Core:Compose:MaterialThemeFromXml"))
-    implementation(project(":Core:UserAvatar"))
 
     implementation(core.androidx.core.ktx)
     implementation(core.material)
     implementation(core.navigation.fragment.ktx)
     implementation(core.kotlinx.serialization.json)
+
+    implementation(core.coil)
+    implementation(core.coil.compose)
 
     // Room
     implementation(core.room.runtime)

--- a/MyKSuite/src/main/java/com/infomaniak/core/myksuite/ui/data/AvatarData.kt
+++ b/MyKSuite/src/main/java/com/infomaniak/core/myksuite/ui/data/AvatarData.kt
@@ -1,0 +1,50 @@
+/*
+ * Infomaniak Core - Android
+ * Copyright (C) 2025 Infomaniak Network SA
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.infomaniak.core.myksuite.ui.data
+
+import android.os.Parcelable
+import androidx.annotation.ColorInt
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.graphics.Color
+import coil3.SingletonImageLoader
+import coil3.compose.LocalPlatformContext
+import com.infomaniak.core.avatar.models.AvatarColors
+import com.infomaniak.core.avatar.models.AvatarType
+import com.infomaniak.core.avatar.models.AvatarUrlData
+import kotlinx.parcelize.Parcelize
+
+@Parcelize
+data class AvatarData(
+    val id: String, // Used for `backgroundColor` computation (ie. the `user.id`, or `correspondent.email`)
+    val uri: String?,
+    val userInitials: String,
+    @ColorInt val initialsColor: Int,
+    @ColorInt val backgroundColor: Int,
+) : Parcelable {
+    @Composable
+    fun toAvatarType(): AvatarType {
+        return AvatarType.getUrlOrInitials(
+            avatarUrlData = uri?.let { AvatarUrlData(it, SingletonImageLoader.get(LocalPlatformContext.current)) },
+            initials = userInitials,
+            colors = AvatarColors(
+                containerColor = Color(backgroundColor),
+                contentColor = Color(initialsColor),
+            ),
+        )
+    }
+}

--- a/MyKSuite/src/main/java/com/infomaniak/core/myksuite/ui/screens/MyKSuiteDashboardScreen.kt
+++ b/MyKSuite/src/main/java/com/infomaniak/core/myksuite/ui/screens/MyKSuiteDashboardScreen.kt
@@ -65,6 +65,7 @@ import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import com.infomaniak.core.avatar.components.Avatar
 import com.infomaniak.core.compose.margin.Margin
 import com.infomaniak.core.extensions.openUrl
 import com.infomaniak.core.myksuite.R
@@ -73,6 +74,7 @@ import com.infomaniak.core.myksuite.ui.components.MyKSuitePrimaryButton
 import com.infomaniak.core.myksuite.ui.components.MyKSuiteTier
 import com.infomaniak.core.myksuite.ui.components.WeightOneSpacer
 import com.infomaniak.core.myksuite.ui.components.myKSuiteGradient
+import com.infomaniak.core.myksuite.ui.data.AvatarData
 import com.infomaniak.core.myksuite.ui.network.ApiRoutes
 import com.infomaniak.core.myksuite.ui.screens.components.ExpandableActionItem
 import com.infomaniak.core.myksuite.ui.screens.components.InformationBlock
@@ -85,8 +87,6 @@ import com.infomaniak.core.myksuite.ui.theme.Dimens
 import com.infomaniak.core.myksuite.ui.theme.LocalMyKSuiteColors
 import com.infomaniak.core.myksuite.ui.theme.MyKSuiteTheme
 import com.infomaniak.core.myksuite.ui.theme.Typography
-import com.infomaniak.core.useravatar.AvatarData
-import com.infomaniak.core.useravatar.exposed.UserAvatar
 import com.infomaniak.core.utils.FORMAT_DATE_SIMPLE
 import com.infomaniak.core.utils.format
 import kotlinx.parcelize.Parcelize
@@ -184,9 +184,9 @@ private fun SubscriptionInfoCard(
             verticalAlignment = Alignment.CenterVertically,
             horizontalArrangement = Arrangement.spacedBy(Margin.Mini),
         ) {
-            UserAvatar(
+            Avatar(
                 modifier = Modifier.size(Dimens.avatarSize),
-                avatarData = dashboardScreenData().avatarData,
+                avatarType = dashboardScreenData().avatarData.toAvatarType(),
                 border = myKSuiteGradient(),
             )
             Text(
@@ -341,7 +341,13 @@ private fun Preview() {
     val dashboardScreenData = MyKSuiteDashboardScreenData(
         myKSuiteTier = MyKSuiteTier.Plus,
         email = "Toto",
-        avatarData = AvatarData(id = "DOUZE", uri = "", userInitials = "IK", iconColor = Color.Red.toArgb()),
+        avatarData = AvatarData(
+            id = "DOUZE",
+            uri = "",
+            userInitials = "IK",
+            initialsColor = Color.White.toArgb(),
+            backgroundColor = Color.DarkGray.toArgb(),
+        ),
         dailySendingLimit = "500",
         kSuiteProductsWithQuotas = listOf(
             KSuiteProductsWithQuotas.Mail(usedSize = "0.2 Go", maxSize = "20 Go", progress = 0.01f),

--- a/MyKSuite/src/main/java/com/infomaniak/core/myksuite/ui/utils/MyKSuiteUiUtils.kt
+++ b/MyKSuite/src/main/java/com/infomaniak/core/myksuite/ui/utils/MyKSuiteUiUtils.kt
@@ -23,6 +23,7 @@ import androidx.core.net.toUri
 import androidx.navigation.NavController
 import androidx.navigation.NavDeepLinkRequest
 import com.infomaniak.core.FormatterFileSize.formatShortFileSize
+import com.infomaniak.core.avatar.getBackgroundColorResBasedOnId
 import com.infomaniak.core.myksuite.ui.data.AvatarData
 import com.infomaniak.core.myksuite.ui.data.MyKSuiteData
 import com.infomaniak.core.myksuite.ui.screens.KSuiteApp
@@ -41,6 +42,10 @@ object MyKSuiteUiUtils {
             .also(::navigate)
     }
 
+    /**
+     * To compute the correct [userInitialsBackgroundColor] for a user, use the [getBackgroundColorResBasedOnId] method
+     * with the appropriate list of colors.
+     */
     fun getDashboardData(
         context: Context,
         myKSuiteData: MyKSuiteData,

--- a/MyKSuite/src/main/java/com/infomaniak/core/myksuite/ui/utils/MyKSuiteUiUtils.kt
+++ b/MyKSuite/src/main/java/com/infomaniak/core/myksuite/ui/utils/MyKSuiteUiUtils.kt
@@ -23,12 +23,12 @@ import androidx.core.net.toUri
 import androidx.navigation.NavController
 import androidx.navigation.NavDeepLinkRequest
 import com.infomaniak.core.FormatterFileSize.formatShortFileSize
+import com.infomaniak.core.myksuite.ui.data.AvatarData
 import com.infomaniak.core.myksuite.ui.data.MyKSuiteData
 import com.infomaniak.core.myksuite.ui.screens.KSuiteApp
 import com.infomaniak.core.myksuite.ui.screens.MyKSuiteDashboardScreenData
 import com.infomaniak.core.myksuite.ui.screens.components.KSuiteProductsWithQuotas
 import com.infomaniak.core.myksuite.ui.views.MyKSuiteUpgradeBottomSheetDialog
-import com.infomaniak.core.useravatar.AvatarData
 
 object MyKSuiteUiUtils {
 
@@ -48,7 +48,7 @@ object MyKSuiteUiUtils {
         avatarUri: String?,
         userInitials: String,
         @ColorInt iconColor: Int,
-        @ColorInt userInitialsBackgroundColor: Int? = null,
+        @ColorInt userInitialsBackgroundColor: Int,
     ): MyKSuiteDashboardScreenData {
         return MyKSuiteDashboardScreenData(
             myKSuiteTier = myKSuiteData.tier,
@@ -57,7 +57,7 @@ object MyKSuiteUiUtils {
                 id = userId.toString(),
                 uri = avatarUri,
                 userInitials = userInitials,
-                iconColor = iconColor,
+                initialsColor = iconColor,
                 backgroundColor = userInitialsBackgroundColor,
             ),
             dailySendingLimit = myKSuiteData.mail.dailyLimitSent.toString(),


### PR DESCRIPTION
Now that we have a new more generic Avatar composable, we can quickly replace the only usage of UserAvatar that was in the MyKsuite module with the new Avatar module to avoid having to support deprecated code.

To avoid modifying the MyKsuite module too much, I copied the AvatarData data class inside of the MyKsuite module so the module can continue to use it and I simply turned it into the required AvatarType at the end.

For now, I did not delete the UserAvatar module because there's another branch which is not yet merged that started using UserAvatar and I would like to talk in perso with the person working on that branch