### PR TITLE
fix: Images loaded from urls avatars now take up the size of the whole avatar

### DIFF
--- a/Avatar/src/main/java/com/infomaniak/core/avatar/components/UrlAvatar.kt
+++ b/Avatar/src/main/java/com/infomaniak/core/avatar/components/UrlAvatar.kt
@@ -18,6 +18,7 @@
 package com.infomaniak.core.avatar.components
 
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.size
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
@@ -53,6 +54,7 @@ internal fun UrlAvatar(avatarType: AvatarType.WithInitials.Url) {
             .build()
 
         AsyncImage(
+            modifier = Modifier.fillMaxSize(),
             model = imageRequest,
             imageLoader = avatarType.imageLoader,
             contentDescription = null,


### PR DESCRIPTION
It used to not take the whole available space of the parent Box