### PR TITLE
refactor(CrossAppLogin): Update ExternalAccount prior to 1st public release

### DIFF
--- a/CrossAppLogin/src/main/kotlin/com/infomaniak/core/login/crossapp/ExternalAccount.kt
+++ b/CrossAppLogin/src/main/kotlin/com/infomaniak/core/login/crossapp/ExternalAccount.kt
@@ -38,17 +38,17 @@ import kotlinx.serialization.protobuf.ProtoNumber
 @Serializable
 data class ExternalAccount(
     @ProtoNumber(1)
-    val fullName: String,
+    val id: Long,
     @ProtoNumber(2)
-    val email: String,
+    val fullName: String,
     @ProtoNumber(3)
-    val avatarUrl: String? = null,
-    @ProtoNumber(4)
-    val isCurrentlySelectedInAnApp: Boolean,
-    @ProtoNumber(5)
-    val tokens: Set<String>,
-    @ProtoNumber(6)
     val initials: String,
+    @ProtoNumber(4)
+    val email: String,
+    @ProtoNumber(5)
+    val avatarUrl: String? = null,
+    @ProtoNumber(6)
+    val isCurrentlySelectedInAnApp: Boolean,
     @ProtoNumber(7)
-    val id: Int,
+    val tokens: Set<String>,
 )

--- a/CrossAppLogin/src/main/kotlin/com/infomaniak/core/login/crossapp/internal/LocalAccounts.kt
+++ b/CrossAppLogin/src/main/kotlin/com/infomaniak/core/login/crossapp/internal/LocalAccounts.kt
@@ -33,13 +33,13 @@ internal fun localAccountsFlow(currentUserIdFlow: Flow<Int?>): Flow<List<Externa
         if (allUsers.none { it.isStaff }) emptyList() else allUsers.map { user ->
             //TODO[CrossAppLogin]: Drop the isStaff condition after successful testing.
             ExternalAccount(
+                id = user.id.toLong(),
                 fullName = user.displayName ?: user.run { "$firstname $lastname" },
+                initials = user.getInitials(),
                 email = user.email,
                 avatarUrl = user.avatar,
                 isCurrentlySelectedInAnApp = user.id == currentUserId,
                 tokens = setOf(user.apiToken.accessToken),
-                initials = user.getInitials(),
-                id = user.id,
             )
         }
     }

--- a/CrossAppLoginUI/src/main/kotlin/com/infomaniak/core/crossloginui/views/CrossLoginListAccountsView.kt
+++ b/CrossAppLoginUI/src/main/kotlin/com/infomaniak/core/crossloginui/views/CrossLoginListAccountsView.kt
@@ -46,7 +46,7 @@ class CrossLoginListAccountsView @JvmOverloads constructor(
 ) : AbstractComposeView(context, attrs, defStyleAttr) {
 
     private val accounts = mutableStateListOf<ExternalAccount>()
-    private val skippedIds = mutableStateSetOf<Int>()
+    private val skippedIds = mutableStateSetOf<Long>()
 
     private var onAnotherAccountClickedListener: (() -> Unit)? = null
     private var onSaveClicked: SaveListener? = null
@@ -118,7 +118,7 @@ class CrossLoginListAccountsView @JvmOverloads constructor(
         }
     }
 
-    fun setSkippedIds(items: Set<Int>) {
+    fun setSkippedIds(items: Set<Long>) {
         skippedIds.apply {
             clear()
             addAll(items)
@@ -134,6 +134,6 @@ class CrossLoginListAccountsView @JvmOverloads constructor(
     }
 
     fun interface SaveListener {
-        fun onSaveClicked(skippedAccountIds: Set<Int>)
+        fun onSaveClicked(skippedAccountIds: Set<Long>)
     }
 }

--- a/CrossAppLoginUI/src/main/kotlin/com/infomaniak/core/crossloginui/views/CrossLoginSelectAccountsView.kt
+++ b/CrossAppLoginUI/src/main/kotlin/com/infomaniak/core/crossloginui/views/CrossLoginSelectAccountsView.kt
@@ -46,7 +46,7 @@ class CrossLoginSelectAccountsView @JvmOverloads constructor(
 ) : AbstractComposeView(context, attrs, defStyleAttr) {
 
     private val accounts = mutableStateListOf<ExternalAccount>()
-    private val skippedIds = mutableStateSetOf<Int>()
+    private val skippedIds = mutableStateSetOf<Long>()
 
     private var onClickListener: OnClickListener? = null
 
@@ -113,7 +113,7 @@ class CrossLoginSelectAccountsView @JvmOverloads constructor(
         }
     }
 
-    fun setSkippedIds(items: Set<Int>) {
+    fun setSkippedIds(items: Set<Long>) {
         skippedIds.apply {
             clear()
             addAll(items)

--- a/CrossAppLoginUI/src/main/kotlin/com/infomaniak/core/crossloginui/views/components/CrossLoginListAccounts.kt
+++ b/CrossAppLoginUI/src/main/kotlin/com/infomaniak/core/crossloginui/views/components/CrossLoginListAccounts.kt
@@ -54,9 +54,9 @@ import com.infomaniak.core.R as RCore
 @Composable
 fun CrossLoginListAccounts(
     accounts: SnapshotStateList<ExternalAccount>,
-    skippedIds: SnapshotStateSet<Int>,
+    skippedIds: SnapshotStateSet<Long>,
     customization: CrossLoginCustomization = CrossLoginDefaults.customize(),
-    onAccountClicked: (Int) -> Unit,
+    onAccountClicked: (Long) -> Unit,
     onAnotherAccountClicked: () -> Unit,
     onSaveClicked: () -> Unit,
 ) {
@@ -125,7 +125,7 @@ private fun Preview(@PreviewParameter(AccountsPreviewParameter::class) accounts:
     Surface {
         CrossLoginListAccounts(
             accounts = remember { mutableStateListOf<ExternalAccount>().apply { addAll(accounts) } },
-            skippedIds = remember { mutableStateSetOf<Int>().apply { add(accounts.first().id) } },
+            skippedIds = remember { mutableStateSetOf<Long>().apply { add(accounts.first().id) } },
             onAccountClicked = {},
             onAnotherAccountClicked = {},
             onSaveClicked = {},

--- a/CrossAppLoginUI/src/main/kotlin/com/infomaniak/core/crossloginui/views/components/CrossLoginSelectAccounts.kt
+++ b/CrossAppLoginUI/src/main/kotlin/com/infomaniak/core/crossloginui/views/components/CrossLoginSelectAccounts.kt
@@ -40,7 +40,7 @@ import com.infomaniak.core.login.crossapp.ExternalAccount
 @Composable
 fun CrossLoginSelectAccounts(
     accounts: SnapshotStateList<ExternalAccount>,
-    skippedIds: SnapshotStateSet<Int>,
+    skippedIds: SnapshotStateSet<Long>,
     customization: CrossLoginCustomization = CrossLoginDefaults.customize(),
     onClick: () -> Unit,
 ) {
@@ -65,7 +65,7 @@ private fun Preview(@PreviewParameter(AccountsPreviewParameter::class) accounts:
     Surface {
         CrossLoginSelectAccounts(
             accounts = remember { mutableStateListOf<ExternalAccount>().apply { addAll(accounts) } },
-            skippedIds = remember { mutableStateSetOf<Int>().apply { add(accounts.last().id) } },
+            skippedIds = remember { mutableStateSetOf<Long>().apply { add(accounts.last().id) } },
             onClick = {},
         )
     }


### PR DESCRIPTION
Use a `Long` for the id, to not have to break compatibility if it ever grows. Reorder properties, and change the proto numbers to be ordered while we can.