### PR TITLE
refactor: Avoid encoding all headers

### DIFF
--- a/Legacy/src/main/java/com/infomaniak/lib/core/InfomaniakCore.kt
+++ b/Legacy/src/main/java/com/infomaniak/lib/core/InfomaniakCore.kt
@@ -20,7 +20,6 @@ package com.infomaniak.lib.core
 import com.infomaniak.lib.core.auth.CredentialManager
 import com.infomaniak.lib.core.utils.ErrorCodeTranslated
 import com.infomaniak.lib.login.InfomaniakLogin.AccessType
-import java.net.URLEncoder
 
 /**
  * InfomaniakCore : Allow to instantiate the library with some parameters
@@ -32,7 +31,7 @@ object InfomaniakCore {
     lateinit var appVersionName: String
     lateinit var clientId: String
     var credentialManager: CredentialManager? = null
-    var customHeaders: MutableSet<CustomHeader> = mutableSetOf()
+    var customHeaders: MutableMap<String, String>? = null
     var apiErrorCodes: List<ErrorCodeTranslated>? = null
     var accessType: AccessType? = AccessType.OFFLINE
 
@@ -42,18 +41,4 @@ object InfomaniakCore {
         this.appVersionName = appVersionName
         this.clientId = clientId
     }
-}
-
-/**
- *  CustomHeader : Represents a custom HTTP header allows defining how the header value should be handled.
- */
-sealed interface CustomHeader {
-    val headerKey: String
-    val headerValue: String
-
-    data class AutoEncodeHeaderToUTF8(override val headerKey: String, private val rawValue: String) : CustomHeader {
-        override val headerValue: String = URLEncoder.encode(rawValue, "UTF-8")
-    }
-
-    data class RawHeader(override val headerKey: String, override val headerValue: String) : CustomHeader
 }

--- a/Legacy/src/main/java/com/infomaniak/lib/core/InfomaniakCore.kt
+++ b/Legacy/src/main/java/com/infomaniak/lib/core/InfomaniakCore.kt
@@ -20,6 +20,7 @@ package com.infomaniak.lib.core
 import com.infomaniak.lib.core.auth.CredentialManager
 import com.infomaniak.lib.core.utils.ErrorCodeTranslated
 import com.infomaniak.lib.login.InfomaniakLogin.AccessType
+import java.net.URLEncoder
 
 /**
  * InfomaniakCore : Allow to instantiate the library with some parameters
@@ -31,19 +32,28 @@ object InfomaniakCore {
     lateinit var appVersionName: String
     lateinit var clientId: String
     var credentialManager: CredentialManager? = null
-    var customHeaders: MutableMap<String, String>? = null
+    var customHeaders: MutableSet<CustomHeader> = mutableSetOf()
     var apiErrorCodes: List<ErrorCodeTranslated>? = null
     var accessType: AccessType? = AccessType.OFFLINE
 
-    fun init(
-        appId: String,
-        appVersionCode: Int,
-        appVersionName: String,
-        clientId: String,
-    ) {
+    fun init(appId: String, appVersionCode: Int, appVersionName: String, clientId: String) {
         this.appId = appId
         this.appVersionCode = appVersionCode
         this.appVersionName = appVersionName
         this.clientId = clientId
     }
+}
+
+/**
+ *  CustomHeader : Represents a custom HTTP header allows defining how the header value should be handled.
+ */
+sealed interface CustomHeader {
+    val headerKey: String
+    val headerValue: String
+
+    data class AutoEncodeHeaderToUTF8(override val headerKey: String, private val rawValue: String) : CustomHeader {
+        override val headerValue: String = URLEncoder.encode(rawValue, "UTF-8")
+    }
+
+    data class RawHeader(override val headerKey: String, override val headerValue: String) : CustomHeader
 }

--- a/Legacy/src/main/java/com/infomaniak/lib/core/networking/HttpUtils.kt
+++ b/Legacy/src/main/java/com/infomaniak/lib/core/networking/HttpUtils.kt
@@ -21,7 +21,6 @@ import android.os.Build
 import com.infomaniak.lib.core.InfomaniakCore
 import com.infomaniak.lib.core.utils.Utils.getPreferredLocaleList
 import okhttp3.Headers
-import java.net.URLEncoder
 
 object HttpUtils {
 
@@ -44,7 +43,7 @@ object HttpUtils {
                 add("Accept-type", it)
                 add("Content-type", it)
             }
-            customHeaders?.forEach { customHeader -> add(customHeader.key, URLEncoder.encode(customHeader.value, "UTF-8")) }
+            customHeaders.forEach { customHeader -> add(customHeader.headerKey, customHeader.headerValue) }
         }.run {
             build()
         }

--- a/Legacy/src/main/java/com/infomaniak/lib/core/networking/HttpUtils.kt
+++ b/Legacy/src/main/java/com/infomaniak/lib/core/networking/HttpUtils.kt
@@ -21,6 +21,7 @@ import android.os.Build
 import com.infomaniak.lib.core.InfomaniakCore
 import com.infomaniak.lib.core.utils.Utils.getPreferredLocaleList
 import okhttp3.Headers
+import java.net.URLEncoder
 
 object HttpUtils {
 
@@ -43,7 +44,7 @@ object HttpUtils {
                 add("Accept-type", it)
                 add("Content-type", it)
             }
-            customHeaders.forEach { customHeader -> add(customHeader.headerKey, customHeader.headerValue) }
+            customHeaders?.forEach { customHeader -> add(customHeader.key, URLEncoder.encode(customHeader.value, "UTF-8")) }
         }.run {
             build()
         }

--- a/Network/src/main/kotlin/com/infomaniak/core/network/NetworkConfiguration.kt
+++ b/Network/src/main/kotlin/com/infomaniak/core/network/NetworkConfiguration.kt
@@ -18,6 +18,7 @@
 
 package com.infomaniak.core.network
 
+import com.infomaniak.core.network.models.CustomHeader
 import com.infomaniak.core.network.utils.ErrorCodeTranslated
 
 /**
@@ -28,7 +29,7 @@ object NetworkConfiguration {
     lateinit var appId: String
     var appVersionCode: Int = -1
     lateinit var appVersionName: String
-    var customHeaders: MutableMap<String, String>? = null
+    var customHeaders: MutableSet<CustomHeader> = mutableSetOf()
     var apiErrorCodes: List<ErrorCodeTranslated>? = null
 
     fun init(

--- a/Network/src/main/kotlin/com/infomaniak/core/network/models/CustomHeader.kt
+++ b/Network/src/main/kotlin/com/infomaniak/core/network/models/CustomHeader.kt
@@ -1,0 +1,17 @@
+package com.infomaniak.core.network.models
+
+import java.net.URLEncoder
+
+/**
+ *  CustomHeader : Represents a custom HTTP header allows defining how the header value should be handled.
+ */
+sealed interface CustomHeader {
+    val key: String
+    val value: String
+
+    data class AutoEncodeHeaderToUTF8(override val key: String, private val rawValue: String) : CustomHeader {
+        override val value: String = URLEncoder.encode(rawValue, "UTF-8")
+    }
+
+    data class RawHeader(override val key: String, override val value: String) : CustomHeader
+}

--- a/Network/src/main/kotlin/com/infomaniak/core/network/networking/HttpUtils.kt
+++ b/Network/src/main/kotlin/com/infomaniak/core/network/networking/HttpUtils.kt
@@ -21,7 +21,6 @@ import android.os.Build
 import com.infomaniak.core.network.NetworkConfiguration
 import com.infomaniak.core.network.utils.Utils.getPreferredLocaleList
 import okhttp3.Headers
-import java.net.URLEncoder
 
 object HttpUtils {
 
@@ -44,7 +43,7 @@ object HttpUtils {
                 add("Accept-type", it)
                 add("Content-type", it)
             }
-            customHeaders?.forEach { customHeader -> add(customHeader.key, URLEncoder.encode(customHeader.value, "UTF-8")) }
+            customHeaders.forEach { customHeader -> add(customHeader.key, customHeader.value) }
         }.run {
             build()
         }


### PR DESCRIPTION
Before all the headers were automatically encoded to UTF8, now we choose the comportment we want for the header.

For now there is two comportment :

      - [AutoEncodeHeaderToUTF8] Automatically encodes the header value to UTF8.
      - [RawHeader] Returns the original value without modification.

But the goal of the [CustomHeader] interface is to define easily another comportment.