### PR TITLE
feat: Create a module for the BasicButton component

### DIFF
--- a/Compose/BasicButton/build.gradle.kts
+++ b/Compose/BasicButton/build.gradle.kts
@@ -1,0 +1,56 @@
+/*
+ * Infomaniak Core - Android
+ * Copyright (C) 2025 Infomaniak Network SA
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+plugins {
+    id("com.android.library")
+    alias(core.plugins.kotlin.android)
+    alias(core.plugins.compose.compiler)
+}
+
+val coreCompileSdk: Int by rootProject.extra
+val coreMinSdk: Int by rootProject.extra
+val javaVersion: JavaVersion by rootProject.extra
+
+android {
+    namespace = "com.infomaniak.core.compose.basicbutton"
+    compileSdk = coreCompileSdk
+
+    defaultConfig {
+        minSdk = coreMinSdk
+    }
+
+    compileOptions {
+        sourceCompatibility = javaVersion
+        targetCompatibility = javaVersion
+    }
+
+    buildFeatures {
+        compose = true
+    }
+
+    kotlinOptions {
+        jvmTarget = javaVersion.toString()
+    }
+}
+
+dependencies {
+    implementation(platform(core.compose.bom))
+    implementation(core.compose.material3)
+    implementation(core.compose.ui)
+    implementation(core.compose.ui.tooling.preview)
+    debugImplementation(core.compose.ui.tooling)
+}

--- a/Compose/BasicButton/src/main/kotlin/com/infomaniak/core/compose/basicbutton/BasicButton.kt
+++ b/Compose/BasicButton/src/main/kotlin/com/infomaniak/core/compose/basicbutton/BasicButton.kt
@@ -58,7 +58,7 @@ import androidx.compose.ui.unit.dp
 @Composable
 fun BasicButton(
     onClick: () -> Unit,
-    modifier: Modifier = Modifier.Companion,
+    modifier: Modifier = Modifier,
     shape: Shape = ButtonDefaults.shape,
     colors: ButtonColors = ButtonDefaults.buttonColors(),
     elevation: ButtonElevation? = ButtonDefaults.buttonElevation(),
@@ -116,8 +116,8 @@ private fun ButtonColors.applyEnabledColorsToDisabled(): ButtonColors {
 
 @Composable
 private fun KeepButtonSize(targetSizeContent: @Composable () -> Unit, content: @Composable () -> Unit) {
-    Box(contentAlignment = Alignment.Companion.Center) {
-        Row(modifier = Modifier.Companion.alpha(0.0f)) {
+    Box(contentAlignment = Alignment.Center) {
+        Row(modifier = Modifier.alpha(0.0f)) {
             targetSizeContent()
         }
         content()
@@ -126,7 +126,7 @@ private fun KeepButtonSize(targetSizeContent: @Composable () -> Unit, content: @
 
 @Composable
 private fun getProgressModifier(): Modifier {
-    val progressModifier = Modifier.Companion
+    val progressModifier = Modifier
         .fillMaxHeight(0.8f)
         .aspectRatio(1f)
     return progressModifier
@@ -152,18 +152,18 @@ private fun Preview() {
             Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
                 Row(horizontalArrangement = Arrangement.spacedBy(12.dp)) {
                     BasicButton(
-                        modifier = Modifier.Companion.height(40.dp),
+                        modifier = Modifier.height(40.dp),
                         onClick = {},
                         content = { Text("Click me!") },
                     )
                     BasicButton(
-                        modifier = Modifier.Companion.height(40.dp),
+                        modifier = Modifier.height(40.dp),
                         onClick = {},
                         content = { Text("Click me!") },
                         enabled = { false },
                     )
                     BasicButton(
-                        modifier = Modifier.Companion.height(40.dp),
+                        modifier = Modifier.height(40.dp),
                         onClick = {},
                         progress = { 0.8f },
                         content = { Text("Click me!") },

--- a/Compose/BasicButton/src/main/kotlin/com/infomaniak/core/compose/basicbutton/BasicButton.kt
+++ b/Compose/BasicButton/src/main/kotlin/com/infomaniak/core/compose/basicbutton/BasicButton.kt
@@ -60,7 +60,7 @@ fun BasicButton(
     onClick: () -> Unit,
     modifier: Modifier = Modifier.Companion,
     shape: Shape = ButtonDefaults.shape,
-    colors: BasicButtonColors = BasicButtonDefaults.colors(),
+    colors: ButtonColors = ButtonDefaults.buttonColors(),
     elevation: ButtonElevation? = ButtonDefaults.buttonElevation(),
     border: BorderStroke? = null,
     enabled: () -> Boolean = { true },
@@ -72,10 +72,8 @@ fun BasicButton(
     val isProgressing by remember(progress) { derivedStateOf { showIndeterminateProgress() || progress != null } }
     val isEnabled = enabled() && isProgressing.not()
 
-    val buttonColors = colors.buttonColors().let { colors ->
-        if (isProgressing) colors.applyEnabledColorsToDisabled() else colors
-    }
-    val progressColors = colors.loaderColors()
+    val buttonColors = if (isProgressing) colors.applyEnabledColorsToDisabled() else colors
+    val progressColors = LoaderColors.fromButtonColors(colors)
 
     Button(
         onClick = onClick,
@@ -134,50 +132,16 @@ private fun getProgressModifier(): Modifier {
     return progressModifier
 }
 
-object BasicButtonDefaults {
-    @Composable
-    fun colors(
-        containerColor: Color = Color.Companion.Unspecified,
-        contentColor: Color = Color.Companion.Unspecified,
-        disabledContainerColor: Color = Color.Companion.Unspecified,
-        disabledContentColor: Color = Color.Companion.Unspecified,
-    ): BasicButtonColors = BasicButtonColors(
-        containerColor = containerColor,
-        contentColor = contentColor,
-        disabledContainerColor = disabledContainerColor,
-        disabledContentColor = disabledContentColor,
-    )
-}
+private data class LoaderColors(val progressColor: Color, val trackColor: Color) {
+    companion object {
+        private const val TRACK_COLOR_ALPHA = 0.3f
 
-data class BasicButtonColors(
-    private val containerColor: Color,
-    private val contentColor: Color,
-    private val disabledContainerColor: Color,
-    private val disabledContentColor: Color,
-) {
-    @Composable
-    fun buttonColors(): ButtonColors = ButtonDefaults.buttonColors(
-        containerColor = containerColor,
-        contentColor = contentColor,
-        disabledContainerColor = disabledContainerColor,
-        disabledContentColor = disabledContentColor,
-    )
-
-    @Composable
-    fun loaderColors(): LoaderColors {
-        val contentColor = buttonColors().contentColor
-        return LoaderColors(
-            progressColor = contentColor,
-            trackColor = contentColor.copy(alpha = TRACK_COLOR_ALPHA),
+        fun fromButtonColors(colors: ButtonColors): LoaderColors = LoaderColors(
+            progressColor = colors.contentColor,
+            trackColor = colors.contentColor.copy(alpha = TRACK_COLOR_ALPHA),
         )
     }
-
-    companion object {
-        const val TRACK_COLOR_ALPHA = 0.3f
-    }
 }
-
-data class LoaderColors(val progressColor: Color, val trackColor: Color)
 
 @Preview(name = "Light")
 @Preview(name = "Dark", uiMode = Configuration.UI_MODE_NIGHT_YES or Configuration.UI_MODE_TYPE_NORMAL)

--- a/Compose/BasicButton/src/main/kotlin/com/infomaniak/core/compose/basicbutton/BasicButton.kt
+++ b/Compose/BasicButton/src/main/kotlin/com/infomaniak/core/compose/basicbutton/BasicButton.kt
@@ -1,0 +1,211 @@
+/*
+ * Infomaniak SwissTransfer - Android
+ * Copyright (C) 2025 Infomaniak Network SA
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.infomaniak.core.compose.basicbutton
+
+import android.content.res.Configuration
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.aspectRatio
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.height
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonColors
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.ButtonElevation
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.derivedStateOf
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.alpha
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.Shape
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+
+/**
+ * Most basic and customizable button component we can share across multiple apps.
+ *
+ * The button adds a "loader" logic to the default material button. Loading behaviors can be controlled through
+ * [showIndeterminateProgress] and [progress].
+ *
+ * Specifying a progress has the priority over specifying showIndeterminateProgress.
+ */
+@Composable
+fun BasicButton(
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier.Companion,
+    shape: Shape = ButtonDefaults.shape,
+    colors: BasicButtonColors = BasicButtonDefaults.colors(),
+    elevation: ButtonElevation? = ButtonDefaults.buttonElevation(),
+    border: BorderStroke? = null,
+    enabled: () -> Boolean = { true },
+    showIndeterminateProgress: () -> Boolean = { false },
+    progress: (() -> Float)? = null,
+    contentPadding: PaddingValues = ButtonDefaults.ContentPadding,
+    content: @Composable () -> Unit,
+) {
+    val isProgressing by remember(progress) { derivedStateOf { showIndeterminateProgress() || progress != null } }
+    val isEnabled = enabled() && isProgressing.not()
+
+    val buttonColors = colors.buttonColors().let { colors ->
+        if (isProgressing) colors.applyEnabledColorsToDisabled() else colors
+    }
+    val progressColors = colors.loaderColors()
+
+    Button(
+        onClick = onClick,
+        modifier = modifier,
+        enabled = isEnabled,
+        shape = shape,
+        colors = buttonColors,
+        elevation = elevation,
+        border = border,
+        contentPadding = contentPadding,
+    ) {
+        when {
+            progress != null -> {
+                KeepButtonSize(content) {
+                    CircularProgressIndicator(
+                        modifier = getProgressModifier(),
+                        color = progressColors.progressColor,
+                        trackColor = progressColors.trackColor,
+                        progress = progress,
+                    )
+                }
+            }
+            showIndeterminateProgress() -> {
+                KeepButtonSize(content) {
+                    CircularProgressIndicator(
+                        modifier = getProgressModifier(),
+                        color = progressColors.progressColor,
+                        trackColor = progressColors.trackColor,
+                    )
+                }
+            }
+            else -> content()
+        }
+    }
+}
+
+private fun ButtonColors.applyEnabledColorsToDisabled(): ButtonColors {
+    return copy(disabledContainerColor = containerColor, disabledContentColor = contentColor)
+}
+
+@Composable
+private fun KeepButtonSize(targetSizeContent: @Composable () -> Unit, content: @Composable () -> Unit) {
+    Box(contentAlignment = Alignment.Companion.Center) {
+        Row(modifier = Modifier.Companion.alpha(0.0f)) {
+            targetSizeContent()
+        }
+        content()
+    }
+}
+
+@Composable
+private fun getProgressModifier(): Modifier {
+    val progressModifier = Modifier.Companion
+        .fillMaxHeight(0.8f)
+        .aspectRatio(1f)
+    return progressModifier
+}
+
+object BasicButtonDefaults {
+    @Composable
+    fun colors(
+        containerColor: Color = Color.Companion.Unspecified,
+        contentColor: Color = Color.Companion.Unspecified,
+        disabledContainerColor: Color = Color.Companion.Unspecified,
+        disabledContentColor: Color = Color.Companion.Unspecified,
+    ): BasicButtonColors = BasicButtonColors(
+        containerColor = containerColor,
+        contentColor = contentColor,
+        disabledContainerColor = disabledContainerColor,
+        disabledContentColor = disabledContentColor,
+    )
+}
+
+data class BasicButtonColors(
+    private val containerColor: Color,
+    private val contentColor: Color,
+    private val disabledContainerColor: Color,
+    private val disabledContentColor: Color,
+) {
+    @Composable
+    fun buttonColors(): ButtonColors = ButtonDefaults.buttonColors(
+        containerColor = containerColor,
+        contentColor = contentColor,
+        disabledContainerColor = disabledContainerColor,
+        disabledContentColor = disabledContentColor,
+    )
+
+    @Composable
+    fun loaderColors(): LoaderColors {
+        val contentColor = buttonColors().contentColor
+        return LoaderColors(
+            progressColor = contentColor,
+            trackColor = contentColor.copy(alpha = TRACK_COLOR_ALPHA),
+        )
+    }
+
+    companion object {
+        const val TRACK_COLOR_ALPHA = 0.3f
+    }
+}
+
+data class LoaderColors(val progressColor: Color, val trackColor: Color)
+
+@Preview(name = "Light")
+@Preview(name = "Dark", uiMode = Configuration.UI_MODE_NIGHT_YES or Configuration.UI_MODE_TYPE_NORMAL)
+@Composable
+private fun Preview() {
+    MaterialTheme {
+        Surface {
+            Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                Row(horizontalArrangement = Arrangement.spacedBy(12.dp)) {
+                    BasicButton(
+                        modifier = Modifier.Companion.height(40.dp),
+                        onClick = {},
+                        content = { Text("Click me!") },
+                    )
+                    BasicButton(
+                        modifier = Modifier.Companion.height(40.dp),
+                        onClick = {},
+                        content = { Text("Click me!") },
+                        enabled = { false },
+                    )
+                    BasicButton(
+                        modifier = Modifier.Companion.height(40.dp),
+                        onClick = {},
+                        progress = { 0.8f },
+                        content = { Text("Click me!") },
+                    )
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Extract a basic button jetpack compose component to its own module so we can easily reuse functionalities across apps. For now it only has the loading functionality. This got extracted and slightly adapted to make it more generic from the SwissTransfer version which was already very generic