### PR TITLE
perf: Run OkHttp's response.body.string() on Dispatchers.IO

### DIFF
--- a/Auth/src/main/kotlin/com/infomaniak/core/auth/api/ApiController.kt
+++ b/Auth/src/main/kotlin/com/infomaniak/core/auth/api/ApiController.kt
@@ -25,9 +25,8 @@ import com.infomaniak.core.network.api.ApiController.RefreshTokenException
 import com.infomaniak.core.network.api.ApiController.gson
 import com.infomaniak.core.network.networking.HttpClient
 import com.infomaniak.core.network.utils.await
+import com.infomaniak.core.network.utils.bodyAsStringOrNull
 import com.infomaniak.lib.login.ApiToken
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.invoke
 import okhttp3.MultipartBody
 import okhttp3.Request
 
@@ -53,7 +52,7 @@ object ApiController {
             .build()
 
         val apiToken = HttpClient.okHttpClient.newCall(request).await().use {
-            val bodyResponse = Dispatchers.IO { it.body?.string() }
+            val bodyResponse = it.bodyAsStringOrNull()
 
             when {
                 it.isSuccessful -> {

--- a/Auth/src/main/kotlin/com/infomaniak/core/auth/api/ApiController.kt
+++ b/Auth/src/main/kotlin/com/infomaniak/core/auth/api/ApiController.kt
@@ -26,6 +26,8 @@ import com.infomaniak.core.network.api.ApiController.gson
 import com.infomaniak.core.network.networking.HttpClient
 import com.infomaniak.core.network.utils.await
 import com.infomaniak.lib.login.ApiToken
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.invoke
 import okhttp3.MultipartBody
 import okhttp3.Request
 
@@ -51,7 +53,7 @@ object ApiController {
             .build()
 
         val apiToken = HttpClient.okHttpClient.newCall(request).await().use {
-            val bodyResponse = it.body?.string()
+            val bodyResponse = Dispatchers.IO { it.body?.string() }
 
             when {
                 it.isSuccessful -> {

--- a/CrossAppLogin/Back/src/main/kotlin/com/infomaniak/core/crossapplogin/back/DerivedTokenGeneratorImpl.kt
+++ b/CrossAppLogin/Back/src/main/kotlin/com/infomaniak/core/crossapplogin/back/DerivedTokenGeneratorImpl.kt
@@ -28,14 +28,13 @@ import com.infomaniak.core.appintegrity.exceptions.NetworkException
 import com.infomaniak.core.cancellable
 import com.infomaniak.core.crossapplogin.back.DerivedTokenGenerator.Issue
 import com.infomaniak.core.network.utils.await
+import com.infomaniak.core.network.utils.bodyAsStringOrNull
 import com.infomaniak.core.sentry.SentryLog
 import com.infomaniak.lib.login.ApiToken
 import com.infomaniak.lib.login.InfomaniakLogin
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Deferred
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.async
-import kotlinx.coroutines.invoke
 import okhttp3.MultipartBody
 import okhttp3.OkHttpClient
 import okhttp3.Request
@@ -112,7 +111,7 @@ class DerivedTokenGeneratorImpl(
             .build()
 
         val response = okHttpClient.newCall(request).await()
-        val bodyResponse = Dispatchers.IO { response.body?.string() }
+        val bodyResponse = response.bodyAsStringOrNull()
 
         return if (response.isSuccessful) {
             val jsonResult = JsonParser.parseString(bodyResponse)

--- a/CrossAppLogin/Back/src/main/kotlin/com/infomaniak/core/crossapplogin/back/DerivedTokenGeneratorImpl.kt
+++ b/CrossAppLogin/Back/src/main/kotlin/com/infomaniak/core/crossapplogin/back/DerivedTokenGeneratorImpl.kt
@@ -33,7 +33,9 @@ import com.infomaniak.lib.login.ApiToken
 import com.infomaniak.lib.login.InfomaniakLogin
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Deferred
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.async
+import kotlinx.coroutines.invoke
 import okhttp3.MultipartBody
 import okhttp3.OkHttpClient
 import okhttp3.Request
@@ -110,7 +112,7 @@ class DerivedTokenGeneratorImpl(
             .build()
 
         val response = okHttpClient.newCall(request).await()
-        val bodyResponse = response.body?.string()
+        val bodyResponse = Dispatchers.IO { response.body?.string() }
 
         return if (response.isSuccessful) {
             val jsonResult = JsonParser.parseString(bodyResponse)

--- a/Legacy/src/main/java/com/infomaniak/lib/core/api/ApiController.kt
+++ b/Legacy/src/main/java/com/infomaniak/lib/core/api/ApiController.kt
@@ -39,6 +39,8 @@ import com.infomaniak.lib.login.ApiToken
 import io.sentry.Sentry
 import io.sentry.SentryLevel
 import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.invoke
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonObject
@@ -135,7 +137,7 @@ object ApiController {
             .build()
 
         val apiToken = HttpClient.okHttpClientNoTokenInterceptor.newCall(request).await().use {
-            val bodyResponse = it.body?.string()
+            val bodyResponse = Dispatchers.IO { it.body?.string() }
 
             when {
                 it.isSuccessful -> {
@@ -194,7 +196,7 @@ object ApiController {
             val request = createRequest(url, method, requestBody)
 
             okHttpClient.newCall(request).await().use { response ->
-                bodyResponse = response.body?.string() ?: ""
+                bodyResponse = Dispatchers.IO { response.body?.string() } ?: ""
                 return when {
                     response.code >= 500 -> {
                         Sentry.captureMessage("An API error ${response.code} occurred", SentryLevel.ERROR) { scope ->

--- a/Legacy/src/main/java/com/infomaniak/lib/core/api/ApiController.kt
+++ b/Legacy/src/main/java/com/infomaniak/lib/core/api/ApiController.kt
@@ -33,14 +33,13 @@ import com.infomaniak.lib.core.networking.ManualAuthorizationRequired
 import com.infomaniak.lib.core.utils.CustomDateTypeAdapter
 import com.infomaniak.lib.core.utils.ErrorCodeTranslated
 import com.infomaniak.lib.core.utils.await
+import com.infomaniak.lib.core.utils.bodyAsStringOrNull
 import com.infomaniak.lib.core.utils.isNetworkException
 import com.infomaniak.lib.core.utils.isSerializationException
 import com.infomaniak.lib.login.ApiToken
 import io.sentry.Sentry
 import io.sentry.SentryLevel
 import kotlinx.coroutines.CancellationException
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.invoke
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonObject
@@ -137,7 +136,7 @@ object ApiController {
             .build()
 
         val apiToken = HttpClient.okHttpClientNoTokenInterceptor.newCall(request).await().use {
-            val bodyResponse = Dispatchers.IO { it.body?.string() }
+            val bodyResponse = it.bodyAsStringOrNull()
 
             when {
                 it.isSuccessful -> {
@@ -196,7 +195,7 @@ object ApiController {
             val request = createRequest(url, method, requestBody)
 
             okHttpClient.newCall(request).await().use { response ->
-                bodyResponse = Dispatchers.IO { response.body?.string() } ?: ""
+                bodyResponse = response.bodyAsStringOrNull() ?: ""
                 return when {
                     response.code >= 500 -> {
                         Sentry.captureMessage("An API error ${response.code} occurred", SentryLevel.ERROR) { scope ->

--- a/Legacy/src/main/java/com/infomaniak/lib/core/fdroidTools/FdroidApiTools.kt
+++ b/Legacy/src/main/java/com/infomaniak/lib/core/fdroidTools/FdroidApiTools.kt
@@ -19,8 +19,8 @@ package com.infomaniak.lib.core.fdroidTools
 
 import com.infomaniak.lib.core.api.ApiController
 import com.infomaniak.lib.core.networking.HttpClient
+import com.infomaniak.lib.core.utils.bodyAsStringOrNull
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.invoke
 import kotlinx.coroutines.withContext
 import okhttp3.Request
 
@@ -31,7 +31,7 @@ class FdroidApiTools {
         var versionCode = 0
         runCatching {
             val response = HttpClient.okHttpClientNoTokenInterceptor.newBuilder().build().newCall(request).execute()
-            val bodyResponse = Dispatchers.IO { response.body?.string() } ?: ""
+            val bodyResponse = response.bodyAsStringOrNull() ?: ""
             if (response.isSuccessful && bodyResponse.isNotBlank()) {
                 versionCode = ApiController.json.decodeFromString<FdroidRelease>(bodyResponse).suggestedVersionCode
             }

--- a/Legacy/src/main/java/com/infomaniak/lib/core/fdroidTools/FdroidApiTools.kt
+++ b/Legacy/src/main/java/com/infomaniak/lib/core/fdroidTools/FdroidApiTools.kt
@@ -20,6 +20,7 @@ package com.infomaniak.lib.core.fdroidTools
 import com.infomaniak.lib.core.api.ApiController
 import com.infomaniak.lib.core.networking.HttpClient
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.invoke
 import kotlinx.coroutines.withContext
 import okhttp3.Request
 
@@ -30,7 +31,7 @@ class FdroidApiTools {
         var versionCode = 0
         runCatching {
             val response = HttpClient.okHttpClientNoTokenInterceptor.newBuilder().build().newCall(request).execute()
-            val bodyResponse = response.body?.string() ?: ""
+            val bodyResponse = Dispatchers.IO { response.body?.string() } ?: ""
             if (response.isSuccessful && bodyResponse.isNotBlank()) {
                 versionCode = ApiController.json.decodeFromString<FdroidRelease>(bodyResponse).suggestedVersionCode
             }

--- a/Legacy/src/main/java/com/infomaniak/lib/core/githubTools/GitHubViewModel.kt
+++ b/Legacy/src/main/java/com/infomaniak/lib/core/githubTools/GitHubViewModel.kt
@@ -52,7 +52,7 @@ class GitHubViewModel : ViewModel() {
     }
 }
 
-
+// Copied from the main Core module this doesn't depend on
 @Suppress("RedundantSuspendModifier")
 private suspend inline fun <T> Result<T>.cancellable(): Result<T> = onFailure {
     if (it is CancellationException) throw it

--- a/Legacy/src/main/java/com/infomaniak/lib/core/githubTools/GitHubViewModel.kt
+++ b/Legacy/src/main/java/com/infomaniak/lib/core/githubTools/GitHubViewModel.kt
@@ -22,6 +22,8 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.liveData
 import com.infomaniak.lib.core.api.ApiController
 import com.infomaniak.lib.core.networking.HttpClient
+import com.infomaniak.lib.core.utils.await
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.invoke
 import okhttp3.Request
@@ -32,7 +34,7 @@ class GitHubViewModel : ViewModel() {
         val request = Request.Builder().url("${API_GITHUB_URL}${repo}/releases").get().build()
         var lastRelease: GitHubRelease? = null
         runCatching {
-            val response = HttpClient.okHttpClientNoTokenInterceptor.newBuilder().build().newCall(request).execute()
+            val response = HttpClient.okHttpClientNoTokenInterceptor.newBuilder().build().newCall(request).await()
             val bodyResponse = Dispatchers.IO { response.body?.string() } ?: ""
             if (response.isSuccessful && bodyResponse.isNotBlank()) {
                 val releases = ApiController.json.decodeFromString<List<GitHubRelease>>(bodyResponse)

--- a/Legacy/src/main/java/com/infomaniak/lib/core/githubTools/GitHubViewModel.kt
+++ b/Legacy/src/main/java/com/infomaniak/lib/core/githubTools/GitHubViewModel.kt
@@ -23,9 +23,9 @@ import androidx.lifecycle.liveData
 import com.infomaniak.lib.core.api.ApiController
 import com.infomaniak.lib.core.networking.HttpClient
 import com.infomaniak.lib.core.utils.await
+import com.infomaniak.lib.core.utils.bodyAsStringOrNull
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.invoke
 import okhttp3.Request
 
 class GitHubViewModel : ViewModel() {
@@ -35,7 +35,7 @@ class GitHubViewModel : ViewModel() {
         var lastRelease: GitHubRelease? = null
         runCatching {
             val response = HttpClient.okHttpClientNoTokenInterceptor.newBuilder().build().newCall(request).await()
-            val bodyResponse = Dispatchers.IO { response.body?.string() } ?: ""
+            val bodyResponse = response.bodyAsStringOrNull() ?: ""
             if (response.isSuccessful && bodyResponse.isNotBlank()) {
                 val releases = ApiController.json.decodeFromString<List<GitHubRelease>>(bodyResponse)
                 lastRelease = releases.find { !it.draft && !it.prerelease }

--- a/Legacy/src/main/java/com/infomaniak/lib/core/githubTools/GitHubViewModel.kt
+++ b/Legacy/src/main/java/com/infomaniak/lib/core/githubTools/GitHubViewModel.kt
@@ -40,7 +40,7 @@ class GitHubViewModel : ViewModel() {
                 val releases = ApiController.json.decodeFromString<List<GitHubRelease>>(bodyResponse)
                 lastRelease = releases.find { !it.draft && !it.prerelease }
             }
-        }.onFailure { exception ->
+        }.cancellable().onFailure { exception ->
             exception.printStackTrace()
         }
 
@@ -50,4 +50,10 @@ class GitHubViewModel : ViewModel() {
     private companion object {
         const val API_GITHUB_URL = "https://api.github.com/repos/Infomaniak/"
     }
+}
+
+
+@Suppress("RedundantSuspendModifier")
+private suspend inline fun <T> Result<T>.cancellable(): Result<T> = onFailure {
+    if (it is CancellationException) throw it
 }

--- a/Legacy/src/main/java/com/infomaniak/lib/core/utils/OkHttpClientExt.kt
+++ b/Legacy/src/main/java/com/infomaniak/lib/core/utils/OkHttpClientExt.kt
@@ -17,6 +17,8 @@
  */
 package com.infomaniak.lib.core.utils
 
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.invoke
 import kotlinx.coroutines.suspendCancellableCoroutine
 import okhttp3.Call
 import okhttp3.Callback
@@ -47,3 +49,5 @@ suspend fun Call.await() = suspendCancellableCoroutine { continuation ->
         runCatching { this@await.cancel() }
     }
 }
+
+suspend fun Response.bodyAsStringOrNull(): String? = Dispatchers.IO { body?.string() }

--- a/Network/src/main/kotlin/com/infomaniak/core/network/api/ApiController.kt
+++ b/Network/src/main/kotlin/com/infomaniak/core/network/api/ApiController.kt
@@ -38,6 +38,8 @@ import com.infomaniak.core.network.utils.await
 import io.sentry.Sentry
 import io.sentry.SentryLevel
 import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.invoke
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonObject
@@ -115,7 +117,7 @@ object ApiController {
             val request = createRequest(url, method, requestBody)
 
             okHttpClient.newCall(request).await().use { response ->
-                bodyResponse = response.body?.string() ?: ""
+                bodyResponse = Dispatchers.IO { response.body?.string() } ?: ""
                 return when {
                     response.code >= 500 -> {
                         Sentry.captureMessage("An API error ${response.code} occurred", SentryLevel.ERROR) { scope ->

--- a/Network/src/main/kotlin/com/infomaniak/core/network/api/ApiController.kt
+++ b/Network/src/main/kotlin/com/infomaniak/core/network/api/ApiController.kt
@@ -35,11 +35,10 @@ import com.infomaniak.core.network.networking.ManualAuthorizationRequired
 import com.infomaniak.core.network.utils.CustomDateTypeAdapter
 import com.infomaniak.core.network.utils.ErrorCodeTranslated
 import com.infomaniak.core.network.utils.await
+import com.infomaniak.core.network.utils.bodyAsStringOrNull
 import io.sentry.Sentry
 import io.sentry.SentryLevel
 import kotlinx.coroutines.CancellationException
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.invoke
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonObject
@@ -117,7 +116,7 @@ object ApiController {
             val request = createRequest(url, method, requestBody)
 
             okHttpClient.newCall(request).await().use { response ->
-                bodyResponse = Dispatchers.IO { response.body?.string() } ?: ""
+                bodyResponse = response.bodyAsStringOrNull() ?: ""
                 return when {
                     response.code >= 500 -> {
                         Sentry.captureMessage("An API error ${response.code} occurred", SentryLevel.ERROR) { scope ->

--- a/Network/src/main/kotlin/com/infomaniak/core/network/utils/OkHttpClientExt.kt
+++ b/Network/src/main/kotlin/com/infomaniak/core/network/utils/OkHttpClientExt.kt
@@ -17,6 +17,8 @@
  */
 package com.infomaniak.core.network.utils
 
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.invoke
 import kotlinx.coroutines.suspendCancellableCoroutine
 import okhttp3.Call
 import okhttp3.Callback
@@ -47,3 +49,5 @@ suspend fun Call.await() = suspendCancellableCoroutine { continuation ->
         runCatching { this@await.cancel() }
     }
 }
+
+suspend fun Response.bodyAsStringOrNull(): String? = Dispatchers.IO { body?.string() }


### PR DESCRIPTION
That is because it will synchronously look into the cache on the device storage.

Caught thanks to StrictMode.

Stacktrace:
```stacktrace
StrictMode policy violation; ~duration=6 ms: android.os.strictmode.DiskReadViolation
	at android.os.StrictMode$AndroidBlockGuardPolicy.onReadFromDisk(StrictMode.java:1683)
	at libcore.io.BlockGuardOs.access(BlockGuardOs.java:74)
	at libcore.io.ForwardingOs.access(ForwardingOs.java:128)
	at android.app.ActivityThread$AndroidOs.access(ActivityThread.java:8582)
	at java.io.UnixFileSystem.checkAccess(UnixFileSystem.java:332)
	at java.io.File.exists(File.java:829)
	at okhttp3.internal.io.FileSystem$Companion$SystemFileSystem.delete(FileSystem.kt:77)
	at okhttp3.internal.io.FileSystem$Companion$SystemFileSystem.rename(FileSystem.kt:88)
	at okhttp3.internal.cache.DiskLruCache.completeEdit$okhttp(DiskLruCache.kt:532)
	at okhttp3.internal.cache.DiskLruCache$Editor.commit(DiskLruCache.kt:901)
	at okhttp3.Cache$RealCacheRequest$1.close(Cache.kt:407)
	at okio.RealBufferedSink.close(RealBufferedSink.kt:287)
	at okhttp3.internal.cache.CacheInterceptor$cacheWritingResponse$cacheWritingSource$1.read(CacheInterceptor.kt:190)
	at okio.Buffer.writeAll(Buffer.kt:1314)
	at okio.RealBufferedSource.readString(RealBufferedSource.kt:99)
	at okhttp3.ResponseBody.string(ResponseBody.kt:187)
	at com.infomaniak.lib.stores.updaterequired.data.api.ApiRepositoryStores.getAppVersion(ApiRepositoryStores.kt:48)
	at com.infomaniak.lib.stores.updaterequired.data.api.ApiRepositoryStores$getAppVersion$1.invokeSuspend(Unknown Source:15)
	at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:33)
	at kotlinx.coroutines.DispatchedTask.run(DispatchedTask.kt:100)
	at android.os.Handler.handleCallback(Handler.java:959)
	at android.os.Handler.dispatchMessage(Handler.java:100)
	at android.os.Looper.loopOnce(Looper.java:232)
	at android.os.Looper.loop(Looper.java:317)
	at android.app.ActivityThread.main(ActivityThread.java:8705)
	at java.lang.reflect.Method.invoke(Native Method)
	at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:580)
	at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:886)
```