### PR TITLE
feat: Display initials while in the loading state when loading an url avatar

### DIFF
--- a/Avatar/src/main/java/com/infomaniak/core/avatar/components/UrlAvatar.kt
+++ b/Avatar/src/main/java/com/infomaniak/core/avatar/components/UrlAvatar.kt
@@ -63,17 +63,21 @@ internal fun UrlAvatar(avatarType: AvatarType.WithInitials.Url) {
         }
     }
 
-    AsyncImage(
-        modifier = Modifier.fillMaxSize(),
-        model = ImageRequest.Builder(LocalContext.current)
+    if (state !is AsyncImagePainter.State.Error) {
+        val imageRequest = ImageRequest.Builder(LocalContext.current)
             .data(avatarType.url)
             .crossfade(true)
-            .build(),
-        imageLoader = avatarType.imageLoader,
-        contentDescription = null,
-        contentScale = ContentScale.Crop,
-        onState = { state = it },
-    )
+            .build()
+
+        AsyncImage(
+            modifier = Modifier.fillMaxSize(),
+            model = imageRequest,
+            imageLoader = avatarType.imageLoader,
+            contentDescription = null,
+            contentScale = ContentScale.Crop,
+            onState = { state = it },
+        )
+    }
 }
 
 @Preview

--- a/Avatar/src/main/java/com/infomaniak/core/avatar/components/UrlAvatar.kt
+++ b/Avatar/src/main/java/com/infomaniak/core/avatar/components/UrlAvatar.kt
@@ -17,51 +17,68 @@
  */
 package com.infomaniak.core.avatar.components
 
+import androidx.compose.animation.Crossfade
+import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.size
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.saveable.rememberSaveable
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalInspectionMode
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import coil3.SingletonImageLoader
-import coil3.compose.AsyncImage
+import coil3.compose.AsyncImagePainter
 import coil3.compose.LocalPlatformContext
+import coil3.compose.rememberAsyncImagePainter
+import coil3.compose.rememberConstraintsSizeResolver
 import coil3.request.ImageRequest
-import coil3.request.crossfade
 import com.infomaniak.core.avatar.models.AvatarColors
 import com.infomaniak.core.avatar.models.AvatarType
 
 @Composable
 internal fun UrlAvatar(avatarType: AvatarType.WithInitials.Url) {
-    var hasErrored by rememberSaveable { mutableStateOf(false) }
-
-    if (hasErrored) {
-        InitialsAvatar(avatarType)
-    } else {
-        val imageRequest = ImageRequest.Builder(LocalContext.current)
+    val sizeResolver = rememberConstraintsSizeResolver()
+    val painter = rememberAsyncImagePainter(
+        model = ImageRequest.Builder(LocalContext.current)
             .data(avatarType.url)
-            .crossfade(true)
-            .build()
+            .size(sizeResolver)
+            .build(),
+        imageLoader = avatarType.imageLoader,
+        contentScale = ContentScale.Crop,
+    )
 
-        AsyncImage(
-            modifier = Modifier.fillMaxSize(),
-            model = imageRequest,
-            imageLoader = avatarType.imageLoader,
-            contentDescription = null,
-            contentScale = ContentScale.Crop,
-            onError = { hasErrored = true },
-        )
+    // Show avatars in preview mode because we can't resolve api calls. The coil3 state will always be in the Empty state which
+    // displays nothing otherwise. Can be removed if we support custom LocalAsyncImagePreviewHandler in preview mode for images.
+    if (LocalInspectionMode.current) InitialsAvatar(avatarType)
+
+    val state by painter.state.collectAsState()
+    Crossfade(state) { localState ->
+        when (localState) {
+            is AsyncImagePainter.State.Error,
+            is AsyncImagePainter.State.Loading -> InitialsAvatar(avatarType)
+            // Don't show anything on empty state because when everything is loaded, the first frame will always have the Empty
+            // state which would otherwise display the initials for a single frame when the image has already been loaded anyway.
+            // I.e. makes it easier on the eye when connection speed is high.
+            AsyncImagePainter.State.Empty,
+            is AsyncImagePainter.State.Success -> Unit
+        }
     }
+
+    Image(
+        modifier = Modifier
+            .fillMaxSize()
+            .then(sizeResolver),
+        painter = painter,
+        contentDescription = null,
+    )
 }
 
 @Preview


### PR DESCRIPTION
Avatars that were loading a url would not display at all during the loading state. Now if the url avatar is loading, display the initials as a placeholder.

Access the image painter state instead of using SubcomposeAsyncImage for the increased performances as described in the documentation