### PR TITLE
fix: Ignore ImpliedQuantity in french

### DIFF
--- a/CrossAppLogin/Front/src/main/res/values-fr/strings.xml
+++ b/CrossAppLogin/Front/src/main/res/values-fr/strings.xml
@@ -17,7 +17,7 @@
   -->
 <resources xmlns:tools="http://schemas.android.com/tools">
     <plurals name="buttonContinueWithAccounts">
-        <item quantity="one">Continuer avec ce compte</item>
+        <item quantity="one" tools:ignore="ImpliedQuantity">Continuer avec ce compte</item>
         <item quantity="other">Continuer avec ces comptes</item>
     </plurals>
     <string name="buttonCreateAccount">Créer un compte</string>


### PR DESCRIPTION
In this situation it's ok because in french only 0 and 1 are grouped together under `quantity=one` which cannot happen in our case