### PR TITLE
chore: Bump github actions versions and add concurrency groups

### DIFF
--- a/.github/workflows/auto-author-assign.yml
+++ b/.github/workflows/auto-author-assign.yml
@@ -4,6 +4,10 @@ on:
   pull_request_target:
     types: [ opened, reopened ]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   pull-requests: write
 
@@ -11,4 +15,4 @@ jobs:
   assign-author:
     runs-on: ubuntu-latest
     steps:
-      - uses: toshimaru/auto-author-assign@v2.1.0
+      - uses: toshimaru/auto-author-assign@v2.1.1

--- a/.github/workflows/dependent-issues.yml
+++ b/.github/workflows/dependent-issues.yml
@@ -18,6 +18,10 @@ on:
       # can be removed.
       - synchronize
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   check:
     runs-on: ubuntu-latest

--- a/.github/workflows/rebase-default-branch.yml
+++ b/.github/workflows/rebase-default-branch.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: git checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5.0.0
         with:
           token: ${{ secrets.REBASE_PR_TOKEN }}
           ref: ${{ github.event.pull_request.head.ref }}
@@ -30,7 +30,7 @@ jobs:
       # Link: https://httgp.com/signing-commits-in-github-actions/
       - name: Import bot's GPG key for signing commits
         id: import-gpg
-        uses: crazy-max/ghaction-import-gpg@v4
+        uses: crazy-max/ghaction-import-gpg@v6.3.0
         with:
           gpg_private_key: ${{ secrets.BOT_GPG_PRIVATE_KEY }}
           passphrase: ${{ secrets.BOT_GPG_PASSPHRASE }}
@@ -54,6 +54,6 @@ jobs:
       # Link: https://github.com/marketplace/actions/actions-ecosystem-remove-labels
       - name: remove label
         if: always()
-        uses: actions-ecosystem/action-remove-labels@v1
+        uses: actions-ecosystem/action-remove-labels@v1.3.0
         with:
           labels: rebase

--- a/.github/workflows/semantic-commit.yml
+++ b/.github/workflows/semantic-commit.yml
@@ -7,6 +7,10 @@ on:
       - reopened
       - synchronize
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   check-commit-message:
     name: Check Commit Message


### PR DESCRIPTION
Adds missing concurrency group block to github workflows. Also bumps version of github actions