### PR TITLE
fix: Connectivity manager improvements

### DIFF
--- a/Network/build.gradle.kts
+++ b/Network/build.gradle.kts
@@ -49,4 +49,5 @@ dependencies {
     implementation(core.okhttp)
     implementation(core.splitties.toast)
     implementation(core.stetho.okhttp3)
+    implementation(core.splitties.systemservices)
 }

--- a/Network/src/main/kotlin/com/infomaniak/core/network/NetworkAvailability.kt
+++ b/Network/src/main/kotlin/com/infomaniak/core/network/NetworkAvailability.kt
@@ -35,10 +35,17 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
+import splitties.systemservices.connectivityManager
 
-class NetworkAvailability(private val context: Context, private val ioDispatcher: CoroutineDispatcher = Dispatchers.IO) {
+class NetworkAvailability(private val ioDispatcher: CoroutineDispatcher = Dispatchers.IO) {
 
-    private val connectivityManager by lazy { context.getSystemService(Context.CONNECTIVITY_SERVICE) as ConnectivityManager }
+    @Deprecated(
+        message = "No need to pass Context",
+        replaceWith = ReplaceWith("NetworkAvailability()"),
+        level = DeprecationLevel.WARNING
+    )
+    constructor(@Suppress("unused") context: Context) : this() // TODO[short-deprecation]: Remove this once apps are updated.
+
     private val mutex = Mutex()
 
     val isNetworkAvailable: Flow<Boolean> = callbackFlow {


### PR DESCRIPTION
This ensures we can't trigger the `ConnectivityManager` related memory leak if we accidentally pass the wrong `Context` (like an `Activity` or a `Service`). See [this issue](https://issuetracker.google.com/issues/37077692).

_Safe to merge thanks to soft deprecation, no main branch incompatibility.
Will update apps and remove deprecated symbols afterwards (by searching for `TODO[short-deprecation]`)._