### PR TITLE
feat: Remove baseline from compose lint plugin

### DIFF
--- a/AppIntegrity/lint-baseline.xml
+++ b/AppIntegrity/lint-baseline.xml
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<issues format="6" by="lint 8.13.0" type="baseline" client="gradle" dependencies="false" name="AGP (8.13.0)" variant="all" version="8.13.0">
-
-</issues>

--- a/AppLock/lint-baseline.xml
+++ b/AppLock/lint-baseline.xml
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<issues format="6" by="lint 8.13.0" type="baseline" client="gradle" dependencies="false" name="AGP (8.13.0)" variant="all" version="8.13.0">
-
-</issues>

--- a/AppVersionChecker/lint-baseline.xml
+++ b/AppVersionChecker/lint-baseline.xml
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<issues format="6" by="lint 8.13.0" type="baseline" client="gradle" dependencies="false" name="AGP (8.13.0)" variant="all" version="8.13.0">
-
-</issues>

--- a/Auth/lint-baseline.xml
+++ b/Auth/lint-baseline.xml
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<issues format="6" by="lint 8.13.0" type="baseline" client="gradle" dependencies="false" name="AGP (8.13.0)" variant="all" version="8.13.0">
-
-</issues>

--- a/Avatar/lint-baseline.xml
+++ b/Avatar/lint-baseline.xml
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<issues format="6" by="lint 8.13.0" type="baseline" client="gradle" dependencies="false" name="AGP (8.13.0)" variant="all" version="8.13.0">
-
-</issues>

--- a/BugTracker/lint-baseline.xml
+++ b/BugTracker/lint-baseline.xml
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<issues format="6" by="lint 8.13.0" type="baseline" client="gradle" dependencies="false" name="AGP (8.13.0)" variant="all" version="8.13.0">
-
-</issues>

--- a/Coil/lint-baseline.xml
+++ b/Coil/lint-baseline.xml
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<issues format="6" by="lint 8.13.0" type="baseline" client="gradle" dependencies="false" name="AGP (8.13.0)" variant="all" version="8.13.0">
-
-</issues>

--- a/Common/lint-baseline.xml
+++ b/Common/lint-baseline.xml
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<issues format="6" by="lint 8.13.0" type="baseline" client="gradle" dependencies="false" name="AGP (8.13.0)" variant="all" version="8.13.0">
-
-</issues>

--- a/CrossAppLogin/Back/lint-baseline.xml
+++ b/CrossAppLogin/Back/lint-baseline.xml
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<issues format="6" by="lint 8.13.0" type="baseline" client="gradle" dependencies="false" name="AGP (8.13.0)" variant="all" version="8.13.0">
-
-</issues>

--- a/CrossAppLogin/Front/build.gradle.kts
+++ b/CrossAppLogin/Front/build.gradle.kts
@@ -50,6 +50,10 @@ android {
     buildFeatures {
         compose = true
     }
+
+    lint {
+        baseline = file("lint-baseline.xml")
+    }
 }
 
 dependencies {

--- a/DotLottie/lint-baseline.xml
+++ b/DotLottie/lint-baseline.xml
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<issues format="6" by="lint 8.13.0" type="baseline" client="gradle" dependencies="false" name="AGP (8.13.0)" variant="all" version="8.13.0">
-
-</issues>

--- a/File/lint-baseline.xml
+++ b/File/lint-baseline.xml
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<issues format="6" by="lint 8.13.0" type="baseline" client="gradle" dependencies="false" name="AGP (8.13.0)" variant="all" version="8.13.0">
-
-</issues>

--- a/FileTypes/lint-baseline.xml
+++ b/FileTypes/lint-baseline.xml
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<issues format="6" by="lint 8.13.0" type="baseline" client="gradle" dependencies="false" name="AGP (8.13.0)" variant="all" version="8.13.0">
-
-</issues>

--- a/FragmentNavigation/lint-baseline.xml
+++ b/FragmentNavigation/lint-baseline.xml
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<issues format="6" by="lint 8.13.0" type="baseline" client="gradle" dependencies="false" name="AGP (8.13.0)" variant="all" version="8.13.0">
-
-</issues>

--- a/InAppReview/lint-baseline.xml
+++ b/InAppReview/lint-baseline.xml
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<issues format="6" by="lint 8.13.0" type="baseline" client="gradle" dependencies="false" name="AGP (8.13.0)" variant="all" version="8.13.0">
-
-</issues>

--- a/InAppUpdate/build.gradle.kts
+++ b/InAppUpdate/build.gradle.kts
@@ -51,6 +51,10 @@ android {
         buildConfig = true
         viewBinding = true
     }
+
+    lint {
+        baseline = file("lint-baseline.xml")
+    }
 }
 
 dependencies {

--- a/KSuite/KSuitePro/build.gradle.kts
+++ b/KSuite/KSuitePro/build.gradle.kts
@@ -50,6 +50,10 @@ android {
     buildFeatures {
         compose = true
     }
+
+    lint {
+        baseline = file("lint-baseline.xml")
+    }
 }
 
 dependencies {

--- a/KSuite/MyKSuite/build.gradle.kts
+++ b/KSuite/MyKSuite/build.gradle.kts
@@ -56,6 +56,10 @@ android {
     buildFeatures {
         compose = true
     }
+
+    lint {
+        baseline = file("lint-baseline.xml")
+    }
 }
 
 dependencies {

--- a/KSuite/lint-baseline.xml
+++ b/KSuite/lint-baseline.xml
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<issues format="6" by="lint 8.13.0" type="baseline" client="gradle" dependencies="false" name="AGP (8.13.0)" variant="all" version="8.13.0">
-
-</issues>

--- a/Ktor/lint-baseline.xml
+++ b/Ktor/lint-baseline.xml
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<issues format="6" by="lint 8.13.0" type="baseline" client="gradle" dependencies="false" name="AGP (8.13.0)" variant="all" version="8.13.0">
-
-</issues>

--- a/Legacy/Confetti/lint-baseline.xml
+++ b/Legacy/Confetti/lint-baseline.xml
@@ -1,5 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<issues name="AGP (8.13.0)" by="lint 8.13.0" client="gradle" dependencies="false" format="6" type="baseline" variant="all"
-    version="8.13.0">
-
-</issues>

--- a/Legacy/lint-baseline.xml
+++ b/Legacy/lint-baseline.xml
@@ -1,5 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<issues name="AGP (8.13.0)" by="lint 8.13.0" client="gradle" dependencies="false" format="6" type="baseline" variant="all"
-    version="8.13.0">
-
-</issues>

--- a/Matomo/lint-baseline.xml
+++ b/Matomo/lint-baseline.xml
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<issues format="6" by="lint 8.13.0" type="baseline" client="gradle" dependencies="false" name="AGP (8.13.0)" variant="all" version="8.13.0">
-
-</issues>

--- a/Network/Ktor/lint-baseline.xml
+++ b/Network/Ktor/lint-baseline.xml
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<issues format="6" by="lint 8.13.0" type="baseline" client="gradle" dependencies="false" name="AGP (8.13.0)" variant="all" version="8.13.0">
-
-</issues>

--- a/Network/Models/lint-baseline.xml
+++ b/Network/Models/lint-baseline.xml
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<issues format="6" by="lint 8.13.0" type="baseline" client="gradle" dependencies="false" name="AGP (8.13.0)" variant="all" version="8.13.0">
-
-</issues>

--- a/Network/lint-baseline.xml
+++ b/Network/lint-baseline.xml
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<issues format="6" by="lint 8.13.0" type="baseline" client="gradle" dependencies="false" name="AGP (8.13.0)" variant="all" version="8.13.0">
-
-</issues>

--- a/Notifications/Registration/lint-baseline.xml
+++ b/Notifications/Registration/lint-baseline.xml
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<issues format="6" by="lint 8.13.0" type="baseline" client="gradle" dependencies="false" name="AGP (8.13.0)" variant="all" version="8.13.0">
-
-</issues>

--- a/Notifications/lint-baseline.xml
+++ b/Notifications/lint-baseline.xml
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<issues format="6" by="lint 8.13.0" type="baseline" client="gradle" dependencies="false" name="AGP (8.13.0)" variant="all" version="8.13.0">
-
-</issues>

--- a/Onboarding/build.gradle.kts
+++ b/Onboarding/build.gradle.kts
@@ -33,6 +33,10 @@ android {
             jvmTarget.set(JvmTarget.fromTarget(javaVersion.toString()))
         }
     }
+
+    lint {
+        baseline = file("lint-baseline.xml")
+    }
 }
 
 dependencies {

--- a/PrivacyManagement/lint-baseline.xml
+++ b/PrivacyManagement/lint-baseline.xml
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<issues format="6" by="lint 8.13.0" type="baseline" client="gradle" dependencies="false" name="AGP (8.13.0)" variant="all" version="8.13.0">
-
-</issues>

--- a/RecyclerView/lint-baseline.xml
+++ b/RecyclerView/lint-baseline.xml
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<issues format="6" by="lint 8.13.0" type="baseline" client="gradle" dependencies="false" name="AGP (8.13.0)" variant="all" version="8.13.0">
-
-</issues>

--- a/Sentry/lint-baseline.xml
+++ b/Sentry/lint-baseline.xml
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<issues format="6" by="lint 8.13.0" type="baseline" client="gradle" dependencies="false" name="AGP (8.13.0)" variant="all" version="8.13.0">
-
-</issues>

--- a/SharedValues/lint-baseline.xml
+++ b/SharedValues/lint-baseline.xml
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<issues format="6" by="lint 8.13.0" type="baseline" client="gradle" dependencies="false" name="AGP (8.13.0)" variant="all" version="8.13.0">
-
-</issues>

--- a/Thumbnails/lint-baseline.xml
+++ b/Thumbnails/lint-baseline.xml
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<issues format="6" by="lint 8.13.0" type="baseline" client="gradle" dependencies="false" name="AGP (8.13.0)" variant="all" version="8.13.0">
-
-</issues>

--- a/TwoFactorAuth/Back/WithUserDb/lint-baseline.xml
+++ b/TwoFactorAuth/Back/WithUserDb/lint-baseline.xml
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<issues format="6" by="lint 8.13.0" type="baseline" client="gradle" dependencies="false" name="AGP (8.13.0)" variant="all" version="8.13.0">
-
-</issues>

--- a/TwoFactorAuth/Back/lint-baseline.xml
+++ b/TwoFactorAuth/Back/lint-baseline.xml
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<issues format="6" by="lint 8.13.0" type="baseline" client="gradle" dependencies="false" name="AGP (8.13.0)" variant="all" version="8.13.0">
-
-</issues>

--- a/TwoFactorAuth/Front/build.gradle.kts
+++ b/TwoFactorAuth/Front/build.gradle.kts
@@ -56,6 +56,10 @@ android {
     buildFeatures {
         compose = true
     }
+
+    lint {
+        baseline = file("lint-baseline.xml")
+    }
 }
 
 dependencies {

--- a/Ui/Compose/AccountBottomSheet/lint-baseline.xml
+++ b/Ui/Compose/AccountBottomSheet/lint-baseline.xml
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<issues format="6" by="lint 8.13.0" type="baseline" client="gradle" dependencies="false" name="AGP (8.13.0)" variant="all" version="8.13.0">
-
-</issues>

--- a/Ui/Compose/BasicButton/lint-baseline.xml
+++ b/Ui/Compose/BasicButton/lint-baseline.xml
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<issues format="6" by="lint 8.13.0" type="baseline" client="gradle" dependencies="false" name="AGP (8.13.0)" variant="all" version="8.13.0">
-
-</issues>

--- a/Ui/Compose/Basics/lint-baseline.xml
+++ b/Ui/Compose/Basics/lint-baseline.xml
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<issues format="6" by="lint 8.13.0" type="baseline" client="gradle" dependencies="false" name="AGP (8.13.0)" variant="all" version="8.13.0">
-
-</issues>

--- a/Ui/Compose/BottomStickyButtonScaffolds/build.gradle.kts
+++ b/Ui/Compose/BottomStickyButtonScaffolds/build.gradle.kts
@@ -49,6 +49,10 @@ android {
             jvmTarget.set(JvmTarget.fromTarget(javaVersion.toString()))
         }
     }
+
+    lint {
+        baseline = file("lint-baseline.xml")
+    }
 }
 
 dependencies {

--- a/Ui/Compose/Margin/lint-baseline.xml
+++ b/Ui/Compose/Margin/lint-baseline.xml
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<issues format="6" by="lint 8.13.0" type="baseline" client="gradle" dependencies="false" name="AGP (8.13.0)" variant="all" version="8.13.0">
-
-</issues>

--- a/Ui/Compose/MaterialThemeFromXml/lint-baseline.xml
+++ b/Ui/Compose/MaterialThemeFromXml/lint-baseline.xml
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<issues format="6" by="lint 8.13.0" type="baseline" client="gradle" dependencies="false" name="AGP (8.13.0)" variant="all" version="8.13.0">
-
-</issues>

--- a/Ui/Compose/Preview/build.gradle.kts
+++ b/Ui/Compose/Preview/build.gradle.kts
@@ -49,6 +49,10 @@ android {
             jvmTarget.set(JvmTarget.fromTarget(javaVersion.toString()))
         }
     }
+
+    lint {
+        baseline = file("lint-baseline.xml")
+    }
 }
 
 dependencies {

--- a/Ui/Compose/Theme/lint-baseline.xml
+++ b/Ui/Compose/Theme/lint-baseline.xml
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<issues format="6" by="lint 8.13.0" type="baseline" client="gradle" dependencies="false" name="AGP (8.13.0)" variant="all" version="8.13.0">
-
-</issues>

--- a/Ui/View/EdgeToEdge/lint-baseline.xml
+++ b/Ui/View/EdgeToEdge/lint-baseline.xml
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<issues format="6" by="lint 8.13.0" type="baseline" client="gradle" dependencies="false" name="AGP (8.13.0)" variant="all" version="8.13.0">
-
-</issues>

--- a/Ui/View/lint-baseline.xml
+++ b/Ui/View/lint-baseline.xml
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<issues format="6" by="lint 8.13.0" type="baseline" client="gradle" dependencies="false" name="AGP (8.13.0)" variant="all" version="8.13.0">
-
-</issues>

--- a/Ui/lint-baseline.xml
+++ b/Ui/lint-baseline.xml
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<issues format="6" by="lint 8.13.0" type="baseline" client="gradle" dependencies="false" name="AGP (8.13.0)" variant="all" version="8.13.0">
-
-</issues>

--- a/WebView/lint-baseline.xml
+++ b/WebView/lint-baseline.xml
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<issues format="6" by="lint 8.13.0" type="baseline" client="gradle" dependencies="false" name="AGP (8.13.0)" variant="all" version="8.13.0">
-
-</issues>

--- a/build-logic/composeLint/src/main/kotlin/com/infomaniak/core/compose/lint/ComposeLintPlugin.kt
+++ b/build-logic/composeLint/src/main/kotlin/com/infomaniak/core/compose/lint/ComposeLintPlugin.kt
@@ -45,8 +45,15 @@ class ComposeLintPlugin : Plugin<Project> {
                     }
                 }
 
-                dependencies {
-                    add("lintChecks", lintLibrary)
+                afterEvaluate {
+                    val androidExt = extensions.findByName("android") as? CommonExtension<*, *, *, *, *, *>
+                        ?: return@afterEvaluate
+
+                    if (androidExt.buildFeatures.compose == true) {
+                        dependencies {
+                            add("lintChecks", lintLibrary)
+                        }
+                    }
                 }
             }
         }

--- a/build-logic/composeLint/src/main/kotlin/com/infomaniak/core/compose/lint/ComposeLintPlugin.kt
+++ b/build-logic/composeLint/src/main/kotlin/com/infomaniak/core/compose/lint/ComposeLintPlugin.kt
@@ -39,10 +39,6 @@ class ComposeLintPlugin : Plugin<Project> {
                     lint {
                         lintConfig = rootProject.file("Core/lint.xml")
 
-                        // Update the baseline for all the subprojects with `./gradlew updateLintBaseline`
-                        // For Core, update the baseline with `./gradlew -p Core updateLintBaseline`
-                        baseline = file("lint-baseline.xml")
-
                         // To updateLintBaseline correctly, temporarily uncomment this line to only include errors and not
                         // warnings in the generated baseline
                         // ignoreWarnings = true

--- a/build-logic/composeLint/src/main/kotlin/com/infomaniak/core/compose/lint/ComposeLintPlugin.kt
+++ b/build-logic/composeLint/src/main/kotlin/com/infomaniak/core/compose/lint/ComposeLintPlugin.kt
@@ -45,15 +45,8 @@ class ComposeLintPlugin : Plugin<Project> {
                     }
                 }
 
-                afterEvaluate {
-                    val androidExt = extensions.findByName("android") as? CommonExtension<*, *, *, *, *, *>
-                        ?: return@afterEvaluate
-
-                    if (androidExt.buildFeatures.compose == true) {
-                        dependencies {
-                            add("lintChecks", lintLibrary)
-                        }
-                    }
+                dependencies {
+                    add("lintChecks", lintLibrary)
                 }
             }
         }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -54,6 +54,10 @@ android {
             jvmTarget.set(JvmTarget.fromTarget(javaVersion.toString()))
         }
     }
+
+    lint {
+        baseline = file("lint-baseline.xml")
+    }
 }
 
 subprojects {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -54,10 +54,6 @@ android {
             jvmTarget.set(JvmTarget.fromTarget(javaVersion.toString()))
         }
     }
-
-    lint {
-        baseline = file("lint-baseline.xml")
-    }
 }
 
 subprojects {


### PR DESCRIPTION
Most modules don't need a baseline because it would simply be empty. Also creating a new module would require to generate an empty baseline for no reason. Now baselines are only defined inside of the few modules that actually need one