### PR TITLE
fix: Add proguard consumer rules to keep some BuildConfig and GoogleApiAvailability field/method

### DIFF
--- a/Sentry/consumer-rules.pro
+++ b/Sentry/consumer-rules.pro
@@ -1,0 +1,13 @@
+# Keep FLAVOR field in app's BuildConfig
+-keep class **.BuildConfig {
+    public static final java.lang.String FLAVOR;
+}
+
+#noinspection ShrinkerUnresolvedReference
+# Keep GoogleApiAvailability for play services detection (comes from app dependency)
+-keep class com.google.android.gms.common.GoogleApiAvailability {
+    #noinspection ShrinkerUnresolvedReference
+    public static com.google.android.gms.common.GoogleApiAvailability getInstance();
+    public int isGooglePlayServicesAvailable(android.content.Context);
+}
+


### PR DESCRIPTION
In previous, I added some method to Sentry using reflection, but some apps are proguarded, so it's needed to add a consumer proguard for these method