### PR TITLE
fix: Re-check up-to-date checks for workers scheduling on user token update

### DIFF
--- a/CrossAppLogin/Back/src/main/kotlin/com/infomaniak/core/crossapplogin/back/internal/deviceinfo/DeviceInfoUpdateManager.kt
+++ b/CrossAppLogin/Back/src/main/kotlin/com/infomaniak/core/crossapplogin/back/internal/deviceinfo/DeviceInfoUpdateManager.kt
@@ -100,9 +100,15 @@ object DeviceInfoUpdateManager : AssociatedUserDataCleanable {
         Dispatchers.Default {
             val crossAppLogin = CrossAppLogin.forContext(context = appCtx, coroutineScope = this)
             crossAppLogin.sharedDeviceIdFlow.collectLatest { currentCrossAppDeviceId ->
+
+                // We need to check for updates when the set of users changes, or when any of their token changes.
+                // When the token is refreshed, the corresponding file is supposed to have been cleared,
+                // so that the up-to-date check triggers a new schedule.
+                //TODO[Core-associated-user-data]: Factorize this duplicate code, and possibly the common logic.
                 val userIdsFlow = UserDatabase().userDao().allUsers.map { users ->
                     users.map { it.id to it.apiToken }
                 }.distinctUntilChanged().map { it.map { (id, _) -> id } }
+
                 userIdsFlow.collect { userIds ->
                     val isEverythingUpToDate = userIds.allConcurrent { isUpToDate(currentCrossAppDeviceId, it.toLong()) }
                     if (isEverythingUpToDate) return@collect

--- a/CrossAppLogin/Back/src/main/kotlin/com/infomaniak/core/crossapplogin/back/internal/deviceinfo/DeviceInfoUpdateManager.kt
+++ b/CrossAppLogin/Back/src/main/kotlin/com/infomaniak/core/crossapplogin/back/internal/deviceinfo/DeviceInfoUpdateManager.kt
@@ -100,7 +100,9 @@ object DeviceInfoUpdateManager : AssociatedUserDataCleanable {
         Dispatchers.Default {
             val crossAppLogin = CrossAppLogin.forContext(context = appCtx, coroutineScope = this)
             crossAppLogin.sharedDeviceIdFlow.collectLatest { currentCrossAppDeviceId ->
-                val userIdsFlow = UserDatabase().userDao().allUsers.map { users -> users.map { it.id } }.distinctUntilChanged()
+                val userIdsFlow = UserDatabase().userDao().allUsers.map { users ->
+                    users.map { it.id to it.apiToken }
+                }.distinctUntilChanged().map { it.map { (id, _) -> id } }
                 userIdsFlow.collect { userIds ->
                     val isEverythingUpToDate = userIds.allConcurrent { isUpToDate(currentCrossAppDeviceId, it.toLong()) }
                     if (isEverythingUpToDate) return@collect

--- a/Notifications/Registration/src/main/kotlin/NotificationsRegistrationManager.kt
+++ b/Notifications/Registration/src/main/kotlin/NotificationsRegistrationManager.kt
@@ -110,7 +110,9 @@ object NotificationsRegistrationManager : AssociatedUserDataCleanable {
             emit(token)
         }.stateIn(this)
 
-        val userIdsFlow = UserDatabase().userDao().allUsers.map { users -> users.map { it.id } }.distinctUntilChanged()
+        val userIdsFlow = UserDatabase().userDao().allUsers.map { users ->
+            users.map { it.id to it.apiToken }
+        }.distinctUntilChanged().map { it.map { (id, _) -> id } }
 
         latestFcmToken.collectLatest { fcmToken ->
             userIdsFlow.collectLatest { userIds ->

--- a/Notifications/Registration/src/main/kotlin/NotificationsRegistrationManager.kt
+++ b/Notifications/Registration/src/main/kotlin/NotificationsRegistrationManager.kt
@@ -110,6 +110,10 @@ object NotificationsRegistrationManager : AssociatedUserDataCleanable {
             emit(token)
         }.stateIn(this)
 
+        // We need to check for updates when the set of users changes, or when any of their token changes.
+        // When the token is refreshed, the corresponding file is supposed to have been cleared,
+        // so that the up-to-date check triggers a new schedule.
+        //TODO[Core-associated-user-data]: Factorize this duplicate code, and possibly the common logic.
         val userIdsFlow = UserDatabase().userDao().allUsers.map { users ->
             users.map { it.id to it.apiToken }
         }.distinctUntilChanged().map { it.map { (id, _) -> id } }


### PR DESCRIPTION
This way, if the last update files are removed before a token update, we will reschedule the worker to send an update with the new token.