### PR TITLE
feat: Make sentryConfig dynamic if the value ever changes

### DIFF
--- a/Sentry/src/main/kotlin/com/infomaniak/core/sentry/SentryConfig.kt
+++ b/Sentry/src/main/kotlin/com/infomaniak/core/sentry/SentryConfig.kt
@@ -31,7 +31,7 @@ import kotlin.coroutines.cancellation.CancellationException
 object SentryConfig {
     fun Application.configureSentry(
         isDebug: Boolean,
-        isSentryTrackingEnabled: Boolean,
+        isSentryTrackingEnabled: () -> Boolean,
         isFilteredException: (Throwable?) -> Boolean = { false }
     ) {
         SentryAndroid.init(this) { options: SentryAndroidOptions ->
@@ -45,7 +45,7 @@ object SentryConfig {
                  * - App specific exceptions defined when the method is called
                  */
                 when {
-                    shouldBeDiscarded(event, isDebug, isSentryTrackingEnabled, isFilteredException) -> null
+                    shouldBeDiscarded(event, isDebug, isSentryTrackingEnabled(), isFilteredException) -> null
                     else -> event
                 }
             }


### PR DESCRIPTION
It used to be configured once for the whole life of the app and if the user changed its parameters it would not update accordingly directly. Now it reads the user parameter's on every "send"