### PR TITLE
feat: Add DataValue module to interact with datastore more easily

### DIFF
--- a/DataValue/build.gradle.kts
+++ b/DataValue/build.gradle.kts
@@ -21,7 +21,6 @@ plugins {
     alias(core.plugins.android.library)
     alias(core.plugins.kotlin.android)
     alias(core.plugins.kotlin.serialization)
-    alias(core.plugins.kotlin.parcelize)
 }
 
 val coreCompileSdk: Int by rootProject.extra

--- a/DataValue/build.gradle.kts
+++ b/DataValue/build.gradle.kts
@@ -1,0 +1,55 @@
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+
+/*
+ * Infomaniak Core - Android
+ * Copyright (C) 2026 Infomaniak Network SA
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+plugins {
+    alias(core.plugins.android.library)
+    alias(core.plugins.kotlin.android)
+    alias(core.plugins.kotlin.serialization)
+    alias(core.plugins.kotlin.parcelize)
+}
+
+val coreCompileSdk: Int by rootProject.extra
+val coreMinSdk: Int by rootProject.extra
+val javaVersion: JavaVersion by rootProject.extra
+
+android {
+    namespace = "com.infomaniak.core.datavalue"
+    compileSdk = coreCompileSdk
+
+    defaultConfig {
+        minSdk = coreMinSdk
+    }
+
+    compileOptions {
+        sourceCompatibility = javaVersion
+        targetCompatibility = javaVersion
+    }
+
+    kotlin {
+        compilerOptions {
+            jvmTarget.set(JvmTarget.fromTarget(javaVersion.toString()))
+        }
+    }
+}
+
+dependencies {
+    implementation(core.androidx.datastore.preferences)
+    implementation(core.kotlinx.coroutines.core)
+    implementation(core.kotlinx.serialization.json)
+}

--- a/DataValue/src/main/kotlin/com/infomaniak/core/datavalue/DataValue.kt
+++ b/DataValue/src/main/kotlin/com/infomaniak/core/datavalue/DataValue.kt
@@ -1,0 +1,43 @@
+/*
+ * Infomaniak Core - Android
+ * Copyright (C) 2026 Infomaniak Network SA
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.infomaniak.core.datavalue
+
+import kotlinx.coroutines.flow.Flow
+
+/**
+ * A single value persisted in a [androidx.datastore.core.DataStore].
+ *
+ * Instances are created through the `dataValue(…)` factories declared in [DataValues] and are meant to be exposed as `val`s:
+ *
+ * ```kotlin
+ * class SettingsDataValues(appContext: Context) : DataValues(appContext, name = "settings") {
+ *     val isUserAGoat = dataValue("isUserAGoat", false)
+ * }
+ * ```
+ */
+interface DataValue<T> {
+
+    /** Emits the current value, then every subsequent value. Consecutive duplicates are filtered out. */
+    val flow: Flow<T>
+
+    /** Persists [value], overwriting whatever was stored previously. */
+    suspend fun setValue(value: T)
+
+    /** Atomically reads the current value, applies [transform], then persists the result. */
+    suspend fun update(transform: (T) -> T)
+}

--- a/DataValue/src/main/kotlin/com/infomaniak/core/datavalue/DataValue.kt
+++ b/DataValue/src/main/kotlin/com/infomaniak/core/datavalue/DataValue.kt
@@ -39,5 +39,5 @@ interface DataValue<T> {
     suspend fun setValue(value: T)
 
     /** Atomically reads the current value, applies [transform], then persists the result. */
-    suspend fun update(transform: (T) -> T)
+    suspend fun update(transform: suspend (T) -> T)
 }

--- a/DataValue/src/main/kotlin/com/infomaniak/core/datavalue/DataValueSerializer.kt
+++ b/DataValue/src/main/kotlin/com/infomaniak/core/datavalue/DataValueSerializer.kt
@@ -1,0 +1,50 @@
+/*
+ * Infomaniak Core - Android
+ * Copyright (C) 2026 Infomaniak Network SA
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.infomaniak.core.datavalue
+
+/**
+ * Describes how to convert a value of type [T] to and from the [String] representation that gets persisted by a [DataValue].
+ *
+ * Implement this for types that are neither primitives, nor [kotlinx.serialization.Serializable] (for instance third-party types
+ * you don't own), then pass the implementation to [DataValues.dataValue]:
+ *
+ * ```kotlin
+ * object UnownedTypeSerializer : DataValueSerializer<UnownedType> {
+ *     override fun serialize(value: UnownedType): String = when (value) {
+ *         UnownedType.A -> "A"
+ *         UnownedType.B -> "B"
+ *     }
+ *
+ *     override fun deserialize(value: String): UnownedType = when (value) {
+ *         "A" -> UnownedType.A
+ *         "B" -> UnownedType.B
+ *     }
+ * }
+ * ```
+ *
+ * Implementations must be stable across app versions: a value produced by [serialize] has to remain readable by
+ * [deserialize] in every future release.
+ */
+interface DataValueSerializer<T> {
+
+    /** Encodes [value] into the [String] that will be stored. */
+    fun serialize(value: T): String
+
+    /** Decodes a previously [serialize]d [String] back into a [T]. */
+    fun deserialize(value: String): T
+}

--- a/DataValue/src/main/kotlin/com/infomaniak/core/datavalue/DataValues.kt
+++ b/DataValue/src/main/kotlin/com/infomaniak/core/datavalue/DataValues.kt
@@ -37,7 +37,6 @@ import kotlinx.coroutines.SupervisorJob
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.serializer
-import java.util.concurrent.ConcurrentHashMap
 
 /**
  * Easy to use wrapper to interact with the DataStore.
@@ -141,15 +140,12 @@ abstract class DataValues(appContext: Context, name: String) {
     companion object {
         private val json by lazy { Json }
 
-        private val dataStores = ConcurrentHashMap<String, DataStore<Preferences>>()
-
-        private fun Context.dataValueStore(name: String): DataStore<Preferences> = dataStores.getOrPut(name) {
+        private fun Context.dataValueStore(name: String): DataStore<Preferences> =
             PreferenceDataStoreFactory.create(
                 // In case of a CorruptionException, clear everything rather than crashing.
                 corruptionHandler = ReplaceFileCorruptionHandler { emptyPreferences() },
                 scope = CoroutineScope(SupervisorJob() + Dispatchers.IO),
                 produceFile = { preferencesDataStoreFile(name) },
             )
-        }
     }
 }

--- a/DataValue/src/main/kotlin/com/infomaniak/core/datavalue/DataValues.kt
+++ b/DataValue/src/main/kotlin/com/infomaniak/core/datavalue/DataValues.kt
@@ -1,0 +1,155 @@
+/*
+ * Infomaniak Core - Android
+ * Copyright (C) 2026 Infomaniak Network SA
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.infomaniak.core.datavalue
+
+import android.content.Context
+import androidx.datastore.core.DataStore
+import androidx.datastore.core.handlers.ReplaceFileCorruptionHandler
+import androidx.datastore.preferences.core.PreferenceDataStoreFactory
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.booleanPreferencesKey
+import androidx.datastore.preferences.core.doublePreferencesKey
+import androidx.datastore.preferences.core.emptyPreferences
+import androidx.datastore.preferences.core.floatPreferencesKey
+import androidx.datastore.preferences.core.intPreferencesKey
+import androidx.datastore.preferences.core.longPreferencesKey
+import androidx.datastore.preferences.core.stringPreferencesKey
+import androidx.datastore.preferences.core.stringSetPreferencesKey
+import androidx.datastore.preferences.preferencesDataStoreFile
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.serializer
+import java.util.concurrent.ConcurrentHashMap
+
+/**
+ * Easy to use wrapper to interact with the DataStore.
+ *
+ * Extend this class to have access the `dataValue()` methods to define and access values stored in the DataStore.
+ *
+ * It supports storing primitive types, serializable types, and their respective nullable versions.
+ */
+abstract class DataValues(appContext: Context, name: String) {
+
+    private val dataStore: DataStore<Preferences> = appContext.applicationContext.dataValueStore(name)
+
+    // region Primitives (stored natively)
+    protected fun dataValue(key: String, defaultValue: Boolean): DataValue<Boolean> =
+        native(booleanPreferencesKey(key), defaultValue)
+
+    protected fun dataValue(key: String, defaultValue: Int): DataValue<Int> =
+        native(intPreferencesKey(key), defaultValue)
+
+    protected fun dataValue(key: String, defaultValue: Long): DataValue<Long> =
+        native(longPreferencesKey(key), defaultValue)
+
+    protected fun dataValue(key: String, defaultValue: Float): DataValue<Float> =
+        native(floatPreferencesKey(key), defaultValue)
+
+    protected fun dataValue(key: String, defaultValue: Double): DataValue<Double> =
+        native(doublePreferencesKey(key), defaultValue)
+
+    protected fun dataValue(key: String, defaultValue: String): DataValue<String> =
+        native(stringPreferencesKey(key), defaultValue)
+
+    protected fun dataValue(key: String, defaultValue: Set<String>): DataValue<Set<String>> =
+        native(stringSetPreferencesKey(key), defaultValue)
+    // endregion
+
+    // region Nullable primitives (stored natively, a null write clears the entry)
+    protected fun dataValue(key: String, defaultValue: Boolean?): DataValue<Boolean?> =
+        nullableNative(booleanPreferencesKey(key), defaultValue)
+
+    protected fun dataValue(key: String, defaultValue: Int?): DataValue<Int?> =
+        nullableNative(intPreferencesKey(key), defaultValue)
+
+    protected fun dataValue(key: String, defaultValue: Long?): DataValue<Long?> =
+        nullableNative(longPreferencesKey(key), defaultValue)
+
+    protected fun dataValue(key: String, defaultValue: Float?): DataValue<Float?> =
+        nullableNative(floatPreferencesKey(key), defaultValue)
+
+    protected fun dataValue(key: String, defaultValue: Double?): DataValue<Double?> =
+        nullableNative(doublePreferencesKey(key), defaultValue)
+
+    @JvmName("dataValueNullableString")
+    protected fun dataValue(key: String, defaultValue: String?): DataValue<String?> =
+        nullableNative(stringPreferencesKey(key), defaultValue)
+
+    @JvmName("dataValueNullableStringSet")
+    protected fun dataValue(key: String, defaultValue: Set<String>?): DataValue<Set<String>?> =
+        nullableNative(stringSetPreferencesKey(key), defaultValue)
+    // endregion
+
+    // region Serializable / custom
+    /**
+     * Stores any [kotlinx.serialization.Serializable] [T] (this includes built-ins such as [Pair], [List], enums…).
+     * Nullable types are supported and round-trip correctly (an explicit `null` is persisted as such).
+     */
+    protected inline fun <reified T> dataValue(key: String, defaultValue: T): DataValue<T> =
+        serializableDataValue(key, defaultValue, serializer())
+
+    /** Stores [T] using a user-provided [DataValueSerializer], for types that aren't natively supported. */
+    protected fun <T> dataValue(key: String, defaultValue: T, serializer: DataValueSerializer<T>): DataValue<T> =
+        build(
+            key = stringPreferencesKey(key),
+            defaultValue = defaultValue,
+            encode = serializer::serialize,
+            decode = serializer::deserialize,
+        )
+    // endregion
+
+    @PublishedApi
+    internal fun <T> serializableDataValue(key: String, defaultValue: T, serializer: KSerializer<T>): DataValue<T> =
+        build(
+            key = stringPreferencesKey(key),
+            defaultValue = defaultValue,
+            encode = { json.encodeToString(serializer, it) },
+            decode = { json.decodeFromString(serializer, it) },
+        )
+
+    private fun <T : Any> native(key: Preferences.Key<T>, defaultValue: T): DataValue<T> =
+        build(key, defaultValue, encode = { it }, decode = { it })
+
+    private fun <T : Any> nullableNative(key: Preferences.Key<T>, defaultValue: T?): DataValue<T?> =
+        build(key, defaultValue, encode = { it }, decode = { it })
+
+    private fun <T, R : Any> build(
+        key: Preferences.Key<R>,
+        defaultValue: T,
+        encode: (T) -> R?,
+        decode: (R) -> T,
+    ): DataValue<T> = PreferenceDataValue(dataStore, key, defaultValue, encode, decode)
+
+    companion object {
+        private val json = Json
+
+        private val dataStores = ConcurrentHashMap<String, DataStore<Preferences>>()
+
+        private fun Context.dataValueStore(name: String): DataStore<Preferences> = dataStores.getOrPut(name) {
+            PreferenceDataStoreFactory.create(
+                // In case of a CorruptionException, clear everything rather than crashing.
+                corruptionHandler = ReplaceFileCorruptionHandler { emptyPreferences() },
+                scope = CoroutineScope(SupervisorJob() + Dispatchers.IO),
+                produceFile = { preferencesDataStoreFile(name) },
+            )
+        }
+    }
+}

--- a/DataValue/src/main/kotlin/com/infomaniak/core/datavalue/DataValues.kt
+++ b/DataValue/src/main/kotlin/com/infomaniak/core/datavalue/DataValues.kt
@@ -139,7 +139,7 @@ abstract class DataValues(appContext: Context, name: String) {
     ): DataValue<T> = PreferenceDataValue(dataStore, key, defaultValue, encode, decode)
 
     companion object {
-        private val json = Json
+        private val json by lazy { Json }
 
         private val dataStores = ConcurrentHashMap<String, DataStore<Preferences>>()
 

--- a/DataValue/src/main/kotlin/com/infomaniak/core/datavalue/DataValues.kt
+++ b/DataValue/src/main/kotlin/com/infomaniak/core/datavalue/DataValues.kt
@@ -42,7 +42,7 @@ import java.util.concurrent.ConcurrentHashMap
 /**
  * Easy to use wrapper to interact with the DataStore.
  *
- * Extend this class to have access the `dataValue()` methods to define and access values stored in the DataStore.
+ * Extend this class to have access to the `dataValue()` methods to define and access values stored in the DataStore.
  *
  * It supports storing primitive types, serializable types, and their respective nullable versions.
  */

--- a/DataValue/src/main/kotlin/com/infomaniak/core/datavalue/PreferenceDataValue.kt
+++ b/DataValue/src/main/kotlin/com/infomaniak/core/datavalue/PreferenceDataValue.kt
@@ -1,0 +1,52 @@
+/*
+ * Infomaniak Core - Android
+ * Copyright (C) 2026 Infomaniak Network SA
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.infomaniak.core.datavalue
+
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.MutablePreferences
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.edit
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.map
+
+internal class PreferenceDataValue<T, R : Any>(
+    private val dataStore: DataStore<Preferences>,
+    private val key: Preferences.Key<R>,
+    private val defaultValue: T,
+    private val encode: (T) -> R?,
+    private val decode: (R) -> T,
+) : DataValue<T> {
+
+    override val flow: Flow<T> = dataStore.data.map { it.read() }.distinctUntilChanged()
+
+    override suspend fun setValue(value: T) {
+        dataStore.edit { it.write(value) }
+    }
+
+    override suspend fun update(transform: (T) -> T) {
+        dataStore.edit { it.write(transform(it.read())) }
+    }
+
+    private fun Preferences.read(): T = this[key]?.let(decode) ?: defaultValue
+
+    private fun MutablePreferences.write(value: T) {
+        val encoded = encode(value)
+        if (encoded == null) remove(key) else set(key, encoded)
+    }
+}

--- a/DataValue/src/main/kotlin/com/infomaniak/core/datavalue/PreferenceDataValue.kt
+++ b/DataValue/src/main/kotlin/com/infomaniak/core/datavalue/PreferenceDataValue.kt
@@ -39,7 +39,7 @@ internal class PreferenceDataValue<T, R : Any>(
         dataStore.edit { it.write(value) }
     }
 
-    override suspend fun update(transform: (T) -> T) {
+    override suspend fun update(transform: suspend (T) -> T) {
         dataStore.edit { it.write(transform(it.read())) }
     }
 

--- a/gradle/core.versions.toml
+++ b/gradle/core.versions.toml
@@ -131,6 +131,7 @@ infomaniak-core-coil = { module = "com.infomaniak.core:Coil" }
 infomaniak-core-common = { module = "com.infomaniak.core:Common" }
 infomaniak-core-crossapplogin = { module = "com.infomaniak.core:CrossAppLogin.Front" }
 infomaniak-core-crossapplogin-back = { module = "com.infomaniak.core:CrossAppLogin.Back" }
+infomaniak-core-datavalue = { module = "com.infomaniak.core:DataValue" }
 infomaniak-core-twofactorauth-back-withuserdb = { module = "com.infomaniak.core:TwoFactorAuth.Back.WithUserDb" }
 infomaniak-core-crossapplogin-front = { module = "com.infomaniak.core:CrossAppLogin.Front" }
 infomaniak-core-dotlottie = { module = "com.infomaniak.core:DotLottie" }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -37,6 +37,7 @@ include(
     ":BugTracker",
     ":Coil",
     ":Common",
+    ":DataValue",
     ":CrossAppLogin:Back",
     ":CrossAppLogin:Front",
     ":DotLottie",


### PR DESCRIPTION
Defining, accessing and editing data store values is a bit heavy and bothersome. This PR adds some wrapper that hides some of the boilerplate code and only exposes straight forward signatures.

It supports storing primitive types, serializable types and their nullable versions. The exposed signatures are type safe.

This new module kind of mimics the way the SharedValues module used to define its values when used which is already the bare minimum data that's required to define a new entry to store