### PR TITLE
chore: Add .github/copilot-instructions.md

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -27,8 +27,7 @@ Legacy/                 # Backward-compatible monolithic module
 build-logic/
 ├── composite/          # CoreCompositePlugin (settings plugin for host apps)
 └── convention/         # Shared Gradle convention plugins
-gradle/libs.versions.toml
-gradle/core.versions.toml  # Exposed to host apps
+gradle/core.versions.toml  # Version catalog — exposed to host apps as the `core` catalog
 lint.xml                   # Shared lint config — applies to all modules
 ```
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,44 @@
+# Copilot Coding Agent Onboarding — android-core
+
+> **Read `AGENTS.md` first** for module map and conventions. This file covers build, CI, and validation.
+
+## Overview
+Infomaniak Android Core — a modular shared library consumed by all Infomaniak Android apps via **Gradle Composite Builds**. Contains ~25 independent modules (Auth, Network, Ui, Ktor, Notifications, etc.) plus a `Legacy` module for backward compatibility.
+
+## One-Time Setup
+No submodules. No env file needed.
+
+## Build & Test (CI: `.github/workflows/android.yml`)
+```bash
+./gradlew clean
+./gradlew build --stacktrace           # compiles all modules
+./gradlew testDebugUnitTest --stacktrace
+```
+CI runs these three steps on every non-draft PR.
+
+## How Apps Consume This Library
+Apps include Core as a **composite build** (not a published artifact). In the host app's `settings.gradle.kts`:
+```kotlin
+pluginManagement { includeBuild("Core/build-logic") }
+plugins { id("com.infomaniak.core.composite") }
+```
+The plugin auto-substitutes `com.infomaniak.core:*` GAV coordinates with local project paths. See `build-logic/composite/src/main/kotlin/com/infomaniak/core/composite/CoreCompositePlugin.kt` for the full mapping.
+
+## Project Layout
+```
+<ModuleName>/           # One directory per module (Auth, Ktor, Ui, Login, Matomo…)
+Legacy/                 # Backward-compatible monolithic module
+build-logic/
+├── composite/          # CoreCompositePlugin (settings plugin for host apps)
+└── convention/         # Shared Gradle convention plugins
+gradle/
+├── libs.versions.toml  # Main version catalog
+└── core.versions.toml  # Exposed to host apps
+lint.xml                # Shared lint config (applied to all modules)
+```
+
+## Key Rules
+- Each module is independently publishable — avoid circular dependencies between modules.
+- `lint.xml` at root applies to all modules; keep lint passing (`./gradlew lint`).
+- Public API changes in any module may break consuming apps — communicate clearly in PR description.
+- When adding/removing a runtime dependency, update `LICENSES.md` at the repo root.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -3,7 +3,7 @@
 > **Read `AGENTS.md` first** for module map and conventions. This file covers build, CI, and validation.
 
 ## Overview
-Infomaniak Android Core — a modular shared library consumed by all Infomaniak Android apps via **Gradle Composite Builds**. Contains ~25 independent modules (Auth, Network, Ui, Ktor, Notifications, etc.) plus a `Legacy` module for backward compatibility.
+Infomaniak Android Core — a modular shared library consumed by all Infomaniak Android apps via **Gradle Composite Builds**. Contains ~50 Gradle modules (Auth, Network, Ui, Ktor, Notifications, etc.) plus a `Legacy` module for backward compatibility.
 
 ## Build & Test (CI: `.github/workflows/android.yml`)
 ```bash
@@ -26,7 +26,7 @@ The plugin substitutes `com.infomaniak.core:*` GAV coords with local project pat
 Legacy/                 # Backward-compatible monolithic module
 build-logic/
 ├── composite/          # CoreCompositePlugin (settings plugin for host apps)
-└── convention/         # Shared Gradle convention plugins
+└── composeLint/        # Shared Compose lint checks
 gradle/core.versions.toml  # Version catalog — exposed to host apps as the `core` catalog
 lint.xml                   # Shared lint config — applies to all modules
 ```

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -5,24 +5,20 @@
 ## Overview
 Infomaniak Android Core — a modular shared library consumed by all Infomaniak Android apps via **Gradle Composite Builds**. Contains ~25 independent modules (Auth, Network, Ui, Ktor, Notifications, etc.) plus a `Legacy` module for backward compatibility.
 
-## One-Time Setup
-No submodules. No env file needed.
-
 ## Build & Test (CI: `.github/workflows/android.yml`)
 ```bash
 ./gradlew clean
-./gradlew build --stacktrace           # compiles all modules
+./gradlew build --stacktrace
 ./gradlew testDebugUnitTest --stacktrace
 ```
-CI runs these three steps on every non-draft PR.
 
 ## How Apps Consume This Library
-Apps include Core as a **composite build** (not a published artifact). In the host app's `settings.gradle.kts`:
 ```kotlin
+// In host app settings.gradle.kts:
 pluginManagement { includeBuild("Core/build-logic") }
 plugins { id("com.infomaniak.core.composite") }
 ```
-The plugin auto-substitutes `com.infomaniak.core:*` GAV coordinates with local project paths. See `build-logic/composite/src/main/kotlin/com/infomaniak/core/composite/CoreCompositePlugin.kt` for the full mapping.
+The plugin substitutes `com.infomaniak.core:*` GAV coords with local project paths. See `CoreCompositePlugin.kt` for the full mapping.
 
 ## Project Layout
 ```
@@ -31,14 +27,15 @@ Legacy/                 # Backward-compatible monolithic module
 build-logic/
 ├── composite/          # CoreCompositePlugin (settings plugin for host apps)
 └── convention/         # Shared Gradle convention plugins
-gradle/
-├── libs.versions.toml  # Main version catalog
-└── core.versions.toml  # Exposed to host apps
-lint.xml                # Shared lint config (applied to all modules)
+gradle/libs.versions.toml
+gradle/core.versions.toml  # Exposed to host apps
+lint.xml                   # Shared lint config — applies to all modules
 ```
 
-## Key Rules
-- Each module is independently publishable — avoid circular dependencies between modules.
-- `lint.xml` at root applies to all modules; keep lint passing (`./gradlew lint`).
-- Public API changes in any module may break consuming apps — communicate clearly in PR description.
+## PR Review Instructions
+
+- Ensure strings are localized via `strings.xml` resources where user-visible text is needed.
+- Each module is independently consumed by apps — avoid introducing circular dependencies between modules.
+- Public API changes in any module may break all consuming apps — document breaking changes clearly in the PR description.
+- `lint.xml` at root applies to all modules — ensure `./gradlew lint` passes before opening a PR.
 - When adding/removing a runtime dependency, update `LICENSES.md` at the repo root.


### PR DESCRIPTION
## Summary
Adds `.github/copilot-instructions.md` to onboard the Copilot cloud agent to this repository.

The file covers:
- What the repository does (purpose, language, architecture)
- One-time environment setup (submodules, env files)
- Build, test, and lint commands that match CI exactly
- Project layout (key paths and modules)
- Rules to prevent common CI failures

## Related
Part of a batch PR across all Infomaniak Android repos to improve Copilot agent quality.
