### PR TITLE
fix(SSO): Fix the security data model crashing the deserialization in SSO

### DIFF
--- a/Auth/src/main/kotlin/com/infomaniak/core/auth/models/user/preferences/security/Security.kt
+++ b/Auth/src/main/kotlin/com/infomaniak/core/auth/models/user/preferences/security/Security.kt
@@ -31,5 +31,5 @@ data class Security(
     var score: Int,
     @SerializedName("date_last_changed_password") @SerialName("date_last_changed_password")
     @ColumnInfo(defaultValue = "0")
-    var dateLastChangedPassword: Long,
+    var dateLastChangedPassword: Long? = null,
 ) : Parcelable

--- a/Auth/src/main/kotlin/com/infomaniak/core/auth/utils/LoginUtils.kt
+++ b/Auth/src/main/kotlin/com/infomaniak/core/auth/utils/LoginUtils.kt
@@ -126,7 +126,8 @@ object LoginUtils {
         apiTokens: List<ApiToken>,
         context: Context,
         userExistenceChecker: UserExistenceChecker,
-    ): List<UserLoginResult> = getUsersByToken(apiTokens, userExistenceChecker, withSecurity = false).map { result ->
+        withSecurity: Boolean = false,
+    ): List<UserLoginResult> = getUsersByToken(apiTokens, userExistenceChecker, withSecurity).map { result ->
         when (result) {
             is UserResult.Success -> UserLoginResult.Success(result.user)
             is UserResult.Failure -> UserLoginResult.Failure(context.getString(result.apiResponse.translateError()))

--- a/Auth/src/main/kotlin/com/infomaniak/core/auth/utils/LoginUtils.kt
+++ b/Auth/src/main/kotlin/com/infomaniak/core/auth/utils/LoginUtils.kt
@@ -35,16 +35,16 @@ import com.infomaniak.core.auth.models.AuthCodeResult
 import com.infomaniak.core.auth.models.UserLoginResult
 import com.infomaniak.core.auth.models.UserResult
 import com.infomaniak.core.common.cancellable
+import com.infomaniak.core.login.ApiToken
+import com.infomaniak.core.login.InfomaniakLogin
+import com.infomaniak.core.login.InfomaniakLogin.ErrorStatus
+import com.infomaniak.core.login.InfomaniakLogin.TokenResult
 import com.infomaniak.core.network.api.ApiController.toApiError
 import com.infomaniak.core.network.api.InternalTranslatedErrorCode
 import com.infomaniak.core.network.models.ApiResponse
 import com.infomaniak.core.network.models.ApiResponseStatus
 import com.infomaniak.core.network.networking.HttpClient
 import com.infomaniak.core.network.utils.ApiErrorCode.Companion.translateError
-import com.infomaniak.core.login.ApiToken
-import com.infomaniak.core.login.InfomaniakLogin
-import com.infomaniak.core.login.InfomaniakLogin.ErrorStatus
-import com.infomaniak.core.login.InfomaniakLogin.TokenResult
 import kotlinx.coroutines.launch
 
 object LoginUtils {
@@ -53,6 +53,7 @@ object LoginUtils {
         infomaniakLogin: InfomaniakLogin,
         userExistenceChecker: UserExistenceChecker,
         onLoginResult: (UserLoginResult?) -> Unit,
+        withSecurity: Boolean = false,
     ): LoginFlowController {
         val scope = rememberCoroutineScope()
         val context = LocalContext.current
@@ -64,6 +65,7 @@ object LoginUtils {
                     context = context,
                     infomaniakLogin = infomaniakLogin,
                     userExistenceChecker = userExistenceChecker,
+                    withSecurity = withSecurity,
                 )
 
                 onLoginResult(userLoginResult)
@@ -91,6 +93,7 @@ object LoginUtils {
         context: Context,
         infomaniakLogin: InfomaniakLogin,
         userExistenceChecker: UserExistenceChecker,
+        withSecurity: Boolean = false,
     ): UserLoginResult? {
         val authCodeResult = result.toAuthCodeResult(context)
         when (authCodeResult) {
@@ -105,7 +108,7 @@ object LoginUtils {
             is TokenResult.Success -> Unit
         }
 
-        val userResult = getUsersByToken(listOf(tokenResult.apiToken), userExistenceChecker).single()
+        val userResult = getUsersByToken(listOf(tokenResult.apiToken), userExistenceChecker, withSecurity).single()
         return when (userResult) {
             is UserResult.Failure -> {
                 UserLoginResult.Failure(context.getString(userResult.apiResponse.translateError()))
@@ -123,7 +126,7 @@ object LoginUtils {
         apiTokens: List<ApiToken>,
         context: Context,
         userExistenceChecker: UserExistenceChecker,
-    ): List<UserLoginResult> = getUsersByToken(apiTokens, userExistenceChecker).map { result ->
+    ): List<UserLoginResult> = getUsersByToken(apiTokens, userExistenceChecker, withSecurity = false).map { result ->
         when (result) {
             is UserResult.Success -> UserLoginResult.Success(result.user)
             is UserResult.Failure -> UserLoginResult.Failure(context.getString(result.apiResponse.translateError()))
@@ -157,9 +160,10 @@ object LoginUtils {
 private suspend fun getUsersByToken(
     apiTokens: List<ApiToken>,
     userExistenceChecker: UserExistenceChecker,
+    withSecurity: Boolean,
 ): List<UserResult> = apiTokens.map { apiToken ->
     runCatching {
-        authenticateUser(apiToken, userExistenceChecker)
+        authenticateUser(apiToken, userExistenceChecker, withSecurity)
     }.cancellable().getOrDefault(UserResult.Failure.Unknown)
 }
 
@@ -186,7 +190,11 @@ private fun Context.formatAuthErrorMessage(errorStatus: ErrorStatus): String {
     )
 }
 
-private suspend fun authenticateUser(apiToken: ApiToken, userExistenceChecker: UserExistenceChecker): UserResult {
+private suspend fun authenticateUser(
+    apiToken: ApiToken,
+    userExistenceChecker: UserExistenceChecker,
+    withSecurity: Boolean,
+): UserResult {
     if (userExistenceChecker.isUserAlreadyPresent(apiToken.userId)) return UserResult.Failure(
         getErrorResponse(InternalTranslatedErrorCode.UserAlreadyPresent)
     )
@@ -196,7 +204,7 @@ private suspend fun authenticateUser(apiToken: ApiToken, userExistenceChecker: U
         chain.proceed(newRequest)
     }.build()
 
-    val userProfileResponse = ApiRepositoryCore.getUserProfile(okhttpClient, withSecurity = true)
+    val userProfileResponse = ApiRepositoryCore.getUserProfile(okhttpClient, withSecurity)
 
     if (userProfileResponse.result == ApiResponseStatus.ERROR) return UserResult.Failure(userProfileResponse)
     val userData = userProfileResponse.data ?: return UserResult.Failure.Unknown


### PR DESCRIPTION
The deserialisation crashes because of the field `dateLastChangedPassword` which is wanting a long, but can be null in cases where we don't use security at all. So this PR make the security object recuperation optional for all app, and only authenticator must "opt-in"