### PR TITLE
feat: Put back rememberLoginFlowController's lamdba as last arg

### DIFF
--- a/Auth/src/main/kotlin/com/infomaniak/core/auth/utils/LoginUtils.kt
+++ b/Auth/src/main/kotlin/com/infomaniak/core/auth/utils/LoginUtils.kt
@@ -52,8 +52,8 @@ object LoginUtils {
     fun rememberLoginFlowController(
         infomaniakLogin: InfomaniakLogin,
         userExistenceChecker: UserExistenceChecker,
-        onLoginResult: suspend (UserLoginResult?) -> Unit,
         withSecurity: Boolean = false,
+        onLoginResult: suspend (UserLoginResult?) -> Unit,
     ): LoginFlowController {
         val scope = rememberCoroutineScope()
         val context = LocalContext.current


### PR DESCRIPTION
The methods used to be called in multiple apps with the lambda defined outside the parenthesis, we put it back to avoid breaking the other apps