### PR TITLE
chore: Remove useless consumer-rules.pro

### DIFF
--- a/Onboarding/consumer-rules.pro
+++ b/Onboarding/consumer-rules.pro
@@ -1,8 +1,0 @@
-# This is due to dotLottie library because of their JNA dependency
-# This will be handled by the library ""soon""
-# https://github.com/LottieFiles/dotlottie-android/issues/78
-
--dontwarn java.awt.Component
--dontwarn java.awt.GraphicsEnvironment
--dontwarn java.awt.HeadlessException
--dontwarn java.awt.Window


### PR DESCRIPTION
It was used to fix an issue with the dotlottie dependency but the issue has been fixed by now and the proguard has been removed from the build.gradle.kts but the file was still there, unused