### PR TITLE
fix(AppIntegrity): Fix support of concurrency

### DIFF
--- a/AppIntegrity/src/fdroid/kotlin/com/infomaniak/core/appintegrity/AppIntegrityManagerFdroid.kt
+++ b/AppIntegrity/src/fdroid/kotlin/com/infomaniak/core/appintegrity/AppIntegrityManagerFdroid.kt
@@ -15,10 +15,13 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
+@file:OptIn(ExperimentalUuidApi::class)
+
 package com.infomaniak.core.appintegrity
 
 import android.content.Context
 import com.infomaniak.core.appintegrity.exceptions.AppIntegrityException
+import kotlin.uuid.ExperimentalUuidApi
 
 class AppIntegrityManager(
     @Suppress("unused") private val appContext: Context,
@@ -43,7 +46,7 @@ class AppIntegrityManager(
     override suspend fun getChallenge() = throw unsupportedException()
 
     override suspend fun requestAttestationToken(
-        challenge: String,
+        challenge: Challenge,
         packageName: String,
         targetUrl: String
     ) = throw unsupportedException()

--- a/AppIntegrity/src/main/kotlin/com/infomaniak/core/appintegrity/AbstractAppIntegrityManager.kt
+++ b/AppIntegrity/src/main/kotlin/com/infomaniak/core/appintegrity/AbstractAppIntegrityManager.kt
@@ -17,6 +17,9 @@
  */
 package com.infomaniak.core.appintegrity
 
+import kotlin.uuid.ExperimentalUuidApi
+import kotlin.uuid.Uuid
+
 abstract class AbstractAppIntegrityManager {
 
     /**
@@ -38,15 +41,17 @@ abstract class AbstractAppIntegrityManager {
 
     abstract suspend fun isGuaranteedToFail(): Boolean
 
-    abstract suspend fun getChallenge(): String
+    @ExperimentalUuidApi
+    abstract suspend fun getChallenge(): Challenge
 
     /**
      * Currently uses classic Play Integrity API.
      *
      * @throws com.infomaniak.core.appintegrity.exceptions.AppIntegrityException
      */
+    @ExperimentalUuidApi
     abstract suspend fun requestAttestationToken(
-        challenge: String,
+        challenge: Challenge,
         packageName: String,
         targetUrl: String,
     ): String
@@ -55,4 +60,10 @@ abstract class AbstractAppIntegrityManager {
      *  Only used to test App Integrity in Apps before their real backend implementation
      */
     open suspend fun callDemoRoute(mobileToken: String) = Unit
+
+    @ExperimentalUuidApi
+    data class Challenge(
+        val id: Uuid,
+        val data: String,
+    )
 }

--- a/AppIntegrity/src/standard/kotlin/com/infomaniak/core/appintegrity/AppIntegrityManager.kt
+++ b/AppIntegrity/src/standard/kotlin/com/infomaniak/core/appintegrity/AppIntegrityManager.kt
@@ -15,6 +15,8 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
+@file:OptIn(ExperimentalUuidApi::class)
+
 package com.infomaniak.core.appintegrity
 
 import android.content.Context
@@ -37,7 +39,8 @@ import io.sentry.Sentry
 import io.sentry.SentryLevel
 import kotlinx.coroutines.tasks.await
 import splitties.init.appCtx
-import java.util.UUID
+import kotlin.uuid.ExperimentalUuidApi
+import kotlin.uuid.Uuid
 
 /**
  * Manager used to verify that the device used is real and doesn't have integrity problems
@@ -51,8 +54,6 @@ class AppIntegrityManager(private val appContext: Context, userAgent: String) : 
     private var appIntegrityTokenProvider: StandardIntegrityTokenProvider? = null
     private val classicIntegrityTokenProvider by lazy { IntegrityManagerFactory.create(appContext) }
     private val appIntegrityRepository by lazy { AppIntegrityRepository(userAgent) }
-
-    private var challengeId = ""
 
     /**
      * This function is needed in case of standard verdict request by [requestIntegrityVerdictToken].
@@ -140,27 +141,31 @@ class AppIntegrityManager(private val appContext: Context, userAgent: String) : 
         }
     }
 
-    override suspend fun getChallenge(): String {
-        generateChallengeId()
-        val apiResponse = appIntegrityRepository.getChallenge(challengeId)
+    override suspend fun getChallenge(): Challenge {
+        val challengeId = Uuid.random()
+        val apiResponse = appIntegrityRepository.getChallenge(challengeId.toString())
         SentryLog.d(
             tag = APP_INTEGRITY_MANAGER_TAG,
-            msg = "challengeId hash : ${challengeId.hashCode()} / challenge hash: ${apiResponse.data.hashCode()}",
+            msg = "challengeId hash : ${challengeId.toString().hashCode()} / challenge hash: ${apiResponse.data.hashCode()}",
         )
-        return apiResponse.data ?: error("Get challenge cannot contain null data")
+        return Challenge(
+            id = challengeId,
+            data = apiResponse.data ?: error("Get challenge cannot contain null data")
+        )
     }
 
     override suspend fun requestAttestationToken(
-        challenge: String,
+        challenge: Challenge,
         packageName: String,
         targetUrl: String
     ): String {
-        val tokenResponse = requestClassicIntegrityVerdictToken(challenge)
-        return getApiIntegrityVerdict(tokenResponse, packageName, targetUrl)
+        val tokenResponse = requestClassicIntegrityVerdictToken(challenge.data)
+        return getApiIntegrityVerdict(tokenResponse, challenge.id, packageName, targetUrl)
     }
 
     private suspend fun getApiIntegrityVerdict(
         integrityToken: IntegrityTokenResponse?,
+        challengeId: Uuid,
         packageName: String,
         targetUrl: String,
     ): String {
@@ -169,7 +174,7 @@ class AppIntegrityManager(private val appContext: Context, userAgent: String) : 
                 integrityToken = integrityToken?.token() ?: "fake integrity token",
                 packageName = packageName,
                 targetUrl = targetUrl,
-                challengeId = challengeId,
+                challengeId = challengeId.toString(),
             )
             return apiResponse.data ?: error("Integrity ApiResponse cannot contain null data")
         }.cancellable().getOrElse { exception ->
@@ -202,10 +207,6 @@ class AppIntegrityManager(private val appContext: Context, userAgent: String) : 
         }.cancellable().getOrElse {
             it.printStackTrace()
         }
-    }
-
-    private fun generateChallengeId() {
-        challengeId = UUID.randomUUID().toString()
     }
 
     private fun manageException(exception: Throwable, errorMessage: String, onFailure: () -> Unit) {

--- a/CrossAppLogin/Back/src/main/kotlin/com/infomaniak/core/crossapplogin/back/DerivedTokenGeneratorImpl.kt
+++ b/CrossAppLogin/Back/src/main/kotlin/com/infomaniak/core/crossapplogin/back/DerivedTokenGeneratorImpl.kt
@@ -37,6 +37,7 @@ import okhttp3.Request
 import okhttp3.RequestBody
 import splitties.init.appCtx
 import java.io.IOException
+import kotlin.uuid.ExperimentalUuidApi
 
 internal class DerivedTokenGeneratorImpl(
     private val tokenRetrievalUrl: String,
@@ -128,6 +129,7 @@ internal class DerivedTokenGeneratorImpl(
         Xor.Second(issue)
     }
 
+    @OptIn(ExperimentalUuidApi::class)
     @Throws(AppIntegrityException::class)
     private suspend inline fun fetchNewAttestationToken(targetUrl: String): String {
         val challenge = appIntegrityManager.getChallenge()


### PR DESCRIPTION
Replace the `challengeId` instance var with a local property that is passed as needed.

This avoids any interference between concurrent requests.

Fixes a bug originally introduced in this commit:

https://github.com/Infomaniak/android-SwissTransfer/commit/5fc2c5055b659de5a9fae7db1cb6ffde5f239f2b