### PR TITLE
feat: Add PaddingValues.onlyHorizontal() helper

### DIFF
--- a/Ui/Compose/Basics/src/main/kotlin/com/infomaniak/core/ui/compose/basics/PaddingValuesExt.kt
+++ b/Ui/Compose/Basics/src/main/kotlin/com/infomaniak/core/ui/compose/basics/PaddingValuesExt.kt
@@ -1,0 +1,33 @@
+/*
+ * Infomaniak Core - Android
+ * Copyright (C) 2026 Infomaniak Network SA
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.infomaniak.core.ui.compose.basics
+
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.calculateEndPadding
+import androidx.compose.foundation.layout.calculateStartPadding
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.platform.LocalLayoutDirection
+
+@Composable
+fun PaddingValues.onlyHorizontal(): PaddingValues {
+    val layoutDirection = LocalLayoutDirection.current
+    return PaddingValues(
+        start = calculateStartPadding(layoutDirection),
+        end = calculateEndPadding(layoutDirection),
+    )
+}


### PR DESCRIPTION
This operation is often needed for content padding handling and is quiet heavy to write by hand everytime so we created this helper function