### PR TITLE
chore: Allow null tokenInterceptorListener in AuthConfiguration.init

### DIFF
--- a/Auth/src/main/kotlin/com/infomaniak/core/auth/AuthConfiguration.kt
+++ b/Auth/src/main/kotlin/com/infomaniak/core/auth/AuthConfiguration.kt
@@ -30,10 +30,13 @@ object AuthConfiguration {
     internal var accessType: AccessType? = AccessType.OFFLINE
         private set
 
+    /**
+     * @param tokenInterceptorListener Set it for apps that can have a selected user.
+     */
     fun init(
         clientId: String,
         accessType: AccessType? = this.accessType,
-        tokenInterceptorListener: TokenInterceptorListener,
+        tokenInterceptorListener: TokenInterceptorListener?,
     ) {
         this.clientIdAsync.complete(clientId)
         this.accessType = accessType


### PR DESCRIPTION
This will support multi-account apps that don't have the concept of a selected account.